### PR TITLE
fix custom ecto type query

### DIFF
--- a/lib/ex_sieve/node.ex
+++ b/lib/ex_sieve/node.ex
@@ -24,6 +24,7 @@ defmodule ExSieve.Node do
   defp result(grouping, sorts), do: {:ok, grouping, sorts}
 
   defp stringify_keys(nil), do: nil
+  defp stringify_keys(%{__struct__: _struct} = value), do: Macro.escape(value)
   defp stringify_keys(map = %{}) do
     map
     |> Enum.map(fn {k, v} -> {to_string(k), stringify_keys(v)} end)

--- a/priv/repo/migrations/1_create_users.exs
+++ b/priv/repo/migrations/1_create_users.exs
@@ -4,6 +4,7 @@ defmodule ExSieve.Repo.Migrations.CreateAuthor do
   def change do
     create table(:users) do
       add :name, :string
+      add :cash, :integer
 
       timestamps
     end

--- a/test/ex_sive_test.exs
+++ b/test/ex_sive_test.exs
@@ -3,7 +3,7 @@ defmodule ExSieveTest do
 
   import Ecto.Query
 
-  alias ExSieve.{Repo, Comment, Config}
+  alias ExSieve.{Repo, Comment, Config, User}
 
   setup do
     {:ok, config: %Config{ignore_errors: false}}
@@ -42,6 +42,14 @@ defmodule ExSieveTest do
                  |> join(:inner, [c], p in assoc(c, :post))
                  |> where([c, p], p.body in ^[body])
                  |> ids
+      assert ids == ecto_ids
+    end
+
+    test "return users with custom type field", %{config: config} do
+      insert_pair(:user)
+
+      ids = User |> ExSieve.filter(%{"cash_lteq" => %Money{amount: 1000}}, config) |> ids
+      ecto_ids = User |> ids
       assert ids == ecto_ids
     end
   end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -20,7 +20,8 @@ defmodule ExSieve.Factory do
 
   def user_factory do
     %ExSieve.User{
-      name: sequence("User #")
+      name: sequence("User #"),
+      cash: Money.new(100)
     }
   end
 end

--- a/test/support/money.ex
+++ b/test/support/money.ex
@@ -1,0 +1,6 @@
+defmodule Money do
+  defstruct amount: 0
+
+  def new(int) when is_integer(int), do: %Money{amount: int}
+  def new(_), do: raise ArgumentError, "expects integer"
+end

--- a/test/support/money_ecto.ex
+++ b/test/support/money_ecto.ex
@@ -1,0 +1,13 @@
+defmodule Money.Ecto.Type do
+  @behaviour Ecto.Type
+
+  def type, do: :integer
+
+  def cast(%Money{}=money), do: {:ok, money}
+  def cast(_), do: :error
+
+  def load(int) when is_integer(int), do: {:ok, Money.new(int)}
+
+  def dump(%Money{amount: amount}), do: {:ok, amount}
+  def dump(_), do: :error
+end

--- a/test/support/user.ex
+++ b/test/support/user.ex
@@ -6,6 +6,7 @@ defmodule ExSieve.User do
     has_many :posts, ExSieve.Post
 
     field :name
+    field :cash, Money.Ecto.Type
 
     timestamps
   end


### PR DESCRIPTION
Allow to pass custom type in a query:

```elixir
User |> ExSieve.filter(%{"cash_lteq" => %Money{amount: 1000}})
```
