### PR TITLE
Fix attribute name matching

### DIFF
--- a/lib/ex_sieve/node/attribute.ex
+++ b/lib/ex_sieve/node/attribute.ex
@@ -30,7 +30,7 @@ defmodule ExSieve.Node.Attribute do
   defp get_assoc(module, key) do
     :associations
     |> module.__schema__
-    |> Enum.find(&String.starts_with?(key, to_string(&1)))
+    |> find_field(key)
   end
 
   defp get_name(%{related: module}, key) do
@@ -39,6 +39,12 @@ defmodule ExSieve.Node.Attribute do
   defp get_name(module, key) do
     :fields
     |> module.__schema__
+    |> find_field(key)
+  end
+
+  defp find_field(fields, key) do
+    fields
+    |> Enum.sort_by(&String.length(to_string(&1)), &>=/2)
     |> Enum.find(&String.starts_with?(key, to_string(&1)))
   end
 end

--- a/test/ex_sieve/node/attribute_test.exs
+++ b/test/ex_sieve/node/attribute_test.exs
@@ -4,7 +4,7 @@ defmodule ExSieve.Node.AttributeTest do
   alias ExSieve.{Node.Attribute, Post, Comment}
 
   describe "ExSieve.Node.Attribute.extract/2" do
-    test "return Attrribute with parent belongs_to" do
+    test "return Attribute with parent belongs_to" do
       assert %Attribute{parent: :post, name: :body} == Attribute.extract("post_body_eq", Comment)
     end
 
@@ -14,6 +14,11 @@ defmodule ExSieve.Node.AttributeTest do
 
     test "return Attribute without parent" do
       assert %Attribute{name: :id, parent: :query} == Attribute.extract("id_eq", Comment)
+    end
+
+    test "return Attributes for schema with similar fields names" do
+      assert %Attribute{name: :published, parent: :query} == Attribute.extract("published_eq", Post)
+      assert %Attribute{name: :published_at, parent: :query} == Attribute.extract("published_at_eq", Post)
     end
 
     test "return Attribute with belongs_to parent" do

--- a/test/support/post.ex
+++ b/test/support/post.ex
@@ -8,6 +8,7 @@ defmodule ExSieve.Post do
     field :title
     field :body
     field :published, :boolean
+    field :published_at, Ecto.DateTime
 
     timestamps
   end


### PR DESCRIPTION
ExSieve.Node.Attribute builds attribute with invalid name for schemes with similar field names:

```elixir
schema "posts" do
  field :published, :boolean
  field :published_at, Ecto.DateTime

  ...
end
```

```elixir
iex(1)> ExSieve.Node.Attribute.extract("published_at_eq", ExSieve.Post)
%ExSieve.Node.Attribute{name: :published, parent: :query}
```

should return ```%ExSieve.Node.Attribute{name: :published_at, parent: :query} ```
