### PR TITLE
Add string versions of @true_values as well

### DIFF
--- a/lib/ex_sieve/builder/where.ex
+++ b/lib/ex_sieve/builder/where.ex
@@ -3,7 +3,8 @@ defmodule ExSieve.Builder.Where do
   alias Ecto.Query.Builder.Filter
   alias ExSieve.Node.{Attribute, Grouping, Condition}
 
-  @true_values [1, '1', 'T', 't', true, 'true', 'TRUE']
+  @true_values [1, '1', 'T', 't', true, 'true', 'TRUE', "1", "T", "t", "true",
+                "TRUE"]
 
   @spec build(Ecto.Queryable.t, Grouping.t, Macro.t) :: Ecto.Query.t
   def build(query, %Grouping{combinator: combinator} = grouping, binding) when combinator in ~w(and or)a do


### PR DESCRIPTION
`ExSieve.Builder.Where` module's `@true_values` module attribute does not contain the string versions of true values only the charlist ones. For example making a request like `http://localhost:4000/users?q[name_null]=true` to list the users with null as a name will result in _no function clause matching in ExSieve.Builder.Where.predicat_expr/3_ error because the true parameter gets passed as a string not a charlist. This PR fixes that.