### PR TITLE
WIP: Add some configuration options for excluding predicates/attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,36 +3,24 @@
 [![Build Status](https://travis-ci.org/valyukov/ex_sieve.svg?branch=master)](https://travis-ci.org/valyukov/ex_sieve) [![Hex Version](http://img.shields.io/hexpm/v/ex_sieve.svg?style=flat)](https://hex.pm/packages/ex_sieve) [![Hex docs](http://img.shields.io/badge/hex.pm-docs-green.svg?style=flat)](https://hexdocs.pm/ex_sieve)
 
 
-ExSieve is filttering solution for Phoenix/Ecto. It builds `Ecto.Query` struct from [ransack](https://github.com/activerecord-hackery/ransack) inspired query language.
+ExSieve is a filttering solution for Phoenix/Ecto. It builds `Ecto.Query` struct from [ransack](https://github.com/activerecord-hackery/ransack) inspired query language.
 
 ## Installation
 
-  1. Add `ex_sieve` to your list of dependencies in `mix.exs`:
+Add `ex_sieve` to your list of dependencies in `mix.exs`:
 
 ```elixir
 def deps do
   [
-    {:ex_sieve, "~> 0.1.0"},
+    {:ex_sieve, "~> 0.6.0"},
   ]
 end
 ```
-
-or use this:
-
-```elixir
-def deps do
-  [
-    {:ex_sieve, github: "valyukov/ex_sieve"},
-  ]
-end
-```
-if you want to stick to mainstream
-
 
 ## Status
 This is a work in progress, here's what is done right now:
 
-- [WIP] Phoenix search form helpers
+- [ ] Phoenix search form helpers
 - [ ] Add advanced search documentation
 - [ ] Custom query function (fragments or custom query functions)
 - [ ] Demo project
@@ -80,26 +68,29 @@ end
 
 ```elixir
 def index(conn, %{"q"=> params}) do
-  posts = MyApp.Post |> MyApp.Repo.filter(params)
+  posts = MyApp.Repo.filter(MyApp.Post, params)
 
   render conn, :index, posts: posts
 end
 ```
 
-Simple query:
+### Examples
+
+#### Simple query
 
 ```json
 {
   "m": "or",
-  "q": {
-    "id_in": [1,2],
-    "title_and_body_cont": "text",
-    "comments_body_eq": "body",
-    "sort": ["title desc", "inserted_at asc"]
+  "id_in": [1, 2],
+  "title_and_body_cont": "text",
+  "comments_body_eq": "body",
+  "s": ["title desc", "inserted_at asc"]
 }
 
 ```
-this is how query translate to the next SQL:
+
+this is how this query istranslate to SQL:
+
 ```sql
 SELECT posts.* FROM posts INNER JOIN comments ON posts.id = comments.post_id \
   WHERE posts.id IN (1, 2) \
@@ -108,7 +99,38 @@ SELECT posts.* FROM posts INNER JOIN comments ON posts.id = comments.post_id \
   ORDER BY posts.title DESC, posts.inserted_at ASC;
 ```
 
-Full list of supported predicates:
+#### Grouping queries
+
+```json
+{
+  "m": "and",
+  "id_in": [1, 2],
+  "g": [
+    {
+      "m": "or",
+      "c": {
+        "title_and_body_cont": "text",
+        "comments_body_eq": "body"
+      }
+    }
+  ],
+  "s": ["title desc", "inserted_at asc"]
+}
+
+```
+
+this is how this query istranslate to SQL:
+
+```sql
+SELECT posts.* FROM posts INNER JOIN comments ON posts.id = comments.post_id \
+  WHERE posts.id IN (1, 2) \
+  AND ( \
+    (posts.title ILIKE '%text%' AND posts.body ILIKE '%text%') \
+    OR comments.body == "body") \
+  ORDER BY posts.title DESC, posts.inserted_at ASC;
+```
+
+### Supported predicates
 
 #### Base predicates
 ```
@@ -137,7 +159,8 @@ blank
 null
 not_null
 ```
-### All predicates
+
+#### All predicates
 ```
 eq
 not_eq
@@ -219,23 +242,16 @@ or
 and
 ```
 
-Example query key value with combinator:
-
-```json
-{
-  "q": {
-    "title_or_body_cont": "text",
-    "inserted_at_and_updated_at_gteq": "2016-09-16T21:32:06"
-   }
-}
-```
-
 Also, you can read more about predicates on [ransack wiki page](https://github.com/activerecord-hackery/ransack/wiki/Basic-Searching)
 
 
-### Advanced query
- Documentating in progress.
- 
+### Excluding predicates and attributes
+
+It is possible to exclude some predicates and/or attributes using the `except_predicates`, `only_predicates`, `except_attributes`, `only_attributes` configuration parameters.
+When used predicates and attributes are excluded as configured with `only_` configuration taking precedence.
+
+Examples in `c:ExSieve.filter/3`.
+
 ## Contributing
 
 First, you'll need to build the test database.

--- a/lib/ex_sieve.ex
+++ b/lib/ex_sieve.ex
@@ -1,31 +1,33 @@
 defmodule ExSieve do
   @moduledoc """
   ExSieve is a object query translator to Ecto.Query.
+
+  ExSieve is meant to be `use`d by a Ecto.Repo.
+
+  When `use`d, an optional keyword list defining default configuration values can be provided.
+  If no options are given the default ones are used.
+  For a detailed explanation of configuration parameters please see the documentation of the
+  `ExSieve.Config` module.
+
+      defmodule MyApp.Repo do
+        use Ecto.Repo,
+          otp_app: :my_app,
+          adapter: Ecto.Adapters.Postgres
+
+        use ExSieve,
+          ignore_erros: true
+      end
+
+    When `use` is called, a `filter` callback is defined in the Repo.
   """
 
   alias ExSieve.{Builder, Config, Node}
 
-  @doc """
-  ExSieve is meant to be `use`d by a Ecto.Repo.
-
-  When `use`d, an optional default for `ignore_erros` can be provided.
-  If `ignore_erros` is not provided, a default of `true` will be used.
-
-      defmodule MyApp.Repo do
-        use Ecto.Repo, otp_app: :my_app
-        use ExSieve
-      end
-
-      defmodule MyApp.Repo do
-        use Ecto.Repo, otp_app: :my_app
-        use ExSieve, ignore_erros: true
-      end
-
-    When `use` is called, a `filter` function is defined in the Repo.
-  """
-
+  @doc false
   defmacro __using__(opts) do
     quote do
+      @behaviour ExSieve
+
       @ex_sieve_defaults unquote(opts)
 
       def filter(queryable, params, options \\ %{}) do
@@ -34,10 +36,46 @@ defmodule ExSieve do
     end
   end
 
-  @typep error :: :attribute_not_found | :predicate_not_found | :direction_not_found | :value_is_empty
+  @type error :: :attribute_not_found | :predicate_not_found | :direction_not_found | :value_is_empty
   @type result :: Ecto.Query.t() | {:error, error}
 
-  @spec filter(Ecto.Queryable.t(), %{(binary | atom) => term}, Config.t()) :: result
+  @type parameters :: %{optional(String.t()) => String.t() | [String.t()] | parameters()}
+
+  @doc """
+  Add filters to the query based on input parameters.
+
+  An optional third argument can be given to override default configuration parameters.
+
+  ## Examples
+
+      iex> params = %{"title_eq" => "foo", "id_in" => [1, 2]}
+      iex> MyApp.Repo.filter(MyApp.Post, params, only_predicates: ["eq"]) |> inspect()
+      "#Ecto.Query<from p0 in MyApp.Post, where: p0.title == ^\\"foo\\">"
+
+      iex> %{"title_eq" => "foo", "id_in" => [1, 2]}
+      iex> MyApp.Repo.filter(MyApp.Post, params, except_predicates: ["eq"]) |> inspect()
+      "#Ecto.Query<from p0 in MyApp.Post, where: p0.id in ^[1, 2]>"
+
+      iex> %{"title_eq" => "foo", "id_in" => [1, 2]}
+      iex> MyApp.Repo.filter(MyApp.Post, params, only_predicates: ["eq"], except_predicates: ["eq"]) |> inspect()
+      "#Ecto.Query<from p0 in MyApp.Post, where: p0.title == ^\\"foo\\">"
+
+      iex> %{"title_eq" => "foo", "user_id_in" => [1, 2]}
+      iex> MyApp.Repo.filter(MyApp.Post, params, only_attributes: ["user_id"]) |> inspect()
+      "#Ecto.Query<from p0 in MyApp.Post, where: p0.user_id in ^[1, 2]>"
+
+      iex> %{"title_eq" => "foo", "user_id_in" => [1, 2]}
+      iex> MyApp.Repo.filter(MyApp.Post, params, except_attributes: ["user_id"]) |> inspect()
+      "#Ecto.Query<from p0 in ExSieve.Post, where: p0.title == ^\\"foo\\">"
+
+      iex> %{"title_eq" => "foo", "user_id_in" => [1, 2]}
+      iex> MyApp.Repo.filter(MyApp.Post, params, only_attributes: ["user_id"], except_attributes: ["user_id"]) |> inspect()
+      "#Ecto.Query<from p0 in MyApp.Post, where: p0.user_id in ^[1, 2]>"
+
+  """
+  @callback filter(queryable :: Ecto.Queryable.t(), parameters(), config :: %{optional(atom) => term()}) :: result()
+
+  @doc false
   def filter(queryable, params, %Config{} = config) do
     params
     |> Node.call(extract_schema(queryable), config)

--- a/lib/ex_sieve/config.ex
+++ b/lib/ex_sieve/config.ex
@@ -1,11 +1,20 @@
 defmodule ExSieve.Config do
   @moduledoc """
-  A `ExSieve.Config` can be created with a `ignore_errors` true or false
-  ```
-  %ExSieve.Config{
-    ignore_errors: true
-  }
-  ```
+  This module defines the structure containing configuration parameters for `ex_sieve`.
+
+  The following options can be set:
+
+    * `ignore_errors` - whether to return an `{:error, _}` tuple as a result or to simply
+       ignore query parameters that generate errors, default `true`.
+
+    * `only_predicates` and `except_predicates` - list of strings containing respectively
+       the only accepted predicates or the excluded ones. If both are not `nil` then
+       `only_predicates` takes precedence. Both default to `nil`.
+
+    * `only_attributes` and `except_attributes` - list of strings containing respectively
+       the only accepted attributes or the excluded ones. If both are not `nil` then
+       `only_attributes` takes precedence. Both default to `nil`.
+
   """
   @defaults [
     ignore_errors: true,
@@ -17,7 +26,13 @@ defmodule ExSieve.Config do
 
   defstruct @defaults
 
-  @type t :: %__MODULE__{}
+  @type t :: %__MODULE__{
+          ignore_errors: boolean(),
+          except_predicates: [String.t()] | nil,
+          only_predicates: [String.t()] | nil,
+          except_attributes: [String.t()] | nil,
+          only_attributes: [String.t()] | nil
+        }
 
   @doc false
   @spec new(Keyword.t(), map | Keyword.t()) :: ExSieve.Config.t()

--- a/lib/ex_sieve/config.ex
+++ b/lib/ex_sieve/config.ex
@@ -10,7 +10,9 @@ defmodule ExSieve.Config do
   @defaults [
     ignore_errors: true,
     except_predicates: nil,
-    only_predicates: nil
+    only_predicates: nil,
+    except_attributes: nil,
+    only_attributes: nil
   ]
 
   defstruct @defaults
@@ -23,7 +25,9 @@ defmodule ExSieve.Config do
     %ExSieve.Config{
       ignore_errors: option_value(:ignore_errors, options, defaults),
       except_predicates: option_value(:except_predicates, options, defaults),
-      only_predicates: option_value(:only_predicates, options, defaults)
+      only_predicates: option_value(:only_predicates, options, defaults),
+      except_attributes: option_value(:except_attributes, options, defaults),
+      only_attributes: option_value(:only_attributes, options, defaults)
     }
   end
 

--- a/lib/ex_sieve/node.ex
+++ b/lib/ex_sieve/node.ex
@@ -9,14 +9,14 @@ defmodule ExSieve.Node do
   @spec call(%{(atom | binary) => term}, atom, Config.t()) :: {:ok, Grouping.t(), list(Sort.t())} | error
   def call(params_with_sort, schema, config) do
     params_with_sort = stringify_keys(params_with_sort)
-    {params, sorts} = extract_sorts(params_with_sort, schema)
+    {params, sorts} = extract_sorts(params_with_sort, schema, config)
     grouping = Grouping.extract(params, schema, config)
     result(grouping, Utils.get_error(sorts, config))
   end
 
-  defp extract_sorts(params, schema) do
+  defp extract_sorts(params, schema, config) do
     {sorts, params} = Map.pop(params, "s", [])
-    {params, Sort.extract(sorts, schema)}
+    {params, Sort.extract(sorts, schema, config)}
   end
 
   defp result({:error, reason}, _sorts), do: {:error, reason}

--- a/lib/ex_sieve/node/attribute.ex
+++ b/lib/ex_sieve/node/attribute.ex
@@ -1,30 +1,36 @@
 defmodule ExSieve.Node.Attribute do
   @moduledoc false
 
-  defstruct name: nil, parent: nil
+  defstruct name: nil, parent: nil, type: nil
 
+  alias ExSieve.{Config, Utils}
   alias ExSieve.Node.Attribute
 
   @type t :: %__MODULE__{}
 
-  @spec extract(String.t(), atom) :: t | {:error, :attribute_not_found}
-  def extract(key, module) do
-    case get_name(module, key) || get_assoc_name(module, key) do
+  @spec extract(String.t(), atom, Config.t()) :: t | {:error, :attribute_not_found}
+  def extract(key, module, config) do
+    only = config.only_attributes
+    except = config.except_attributes
+
+    case get_name(module, key, only, except) || get_assoc_name(module, key, only, except) do
       nil -> {:error, :attribute_not_found}
       {_assoc, nil} -> {:error, :attribute_not_found}
-      {assoc, name} -> %Attribute{parent: assoc, name: name}
-      name -> %Attribute{parent: :query, name: name}
+      {assoc, name} -> %Attribute{parent: String.to_atom(assoc), name: String.to_atom(name)}
+      name -> %Attribute{parent: :query, name: String.to_atom(name)}
     end
   end
 
-  defp get_assoc_name(module, key) do
+  defp get_assoc_name(module, key, only, except) do
     case get_assoc(module, key) do
       nil ->
         nil
 
       assoc ->
         key = String.replace_prefix(key, "#{assoc}_", "")
-        {assoc, get_name(module.__schema__(:association, assoc), key)}
+        only = filter_only_except_for_assoc(assoc, only)
+        except = filter_only_except_for_assoc(assoc, except)
+        {assoc, get_name(module.__schema__(:association, String.to_atom(assoc)), key, only, except)}
     end
   end
 
@@ -34,17 +40,27 @@ defmodule ExSieve.Node.Attribute do
     |> find_field(key)
   end
 
-  defp get_name(%{related: module}, key), do: get_name(module, key)
+  defp get_name(%{related: module}, key, only, except), do: get_name(module, key, only, except)
 
-  defp get_name(module, key) do
+  defp get_name(module, key, only, except) do
     :fields
     |> module.__schema__()
-    |> find_field(key)
+    |> find_field(key, only, except)
   end
 
-  defp find_field(fields, key) do
+  defp find_field(fields, key, only \\ nil, except \\ nil) do
     fields
-    |> Enum.sort_by(&String.length(to_string(&1)), &>=/2)
-    |> Enum.find(&String.starts_with?(key, to_string(&1)))
+    |> Enum.map(&Atom.to_string/1)
+    |> Utils.filter(only, except)
+    |> Enum.sort_by(&String.length/1, &>=/2)
+    |> Enum.find(&String.starts_with?(key, &1))
   end
+
+  defp filter_only_except_for_assoc(prefix, list) when is_list(list) do
+    list
+    |> Enum.filter(&String.starts_with?(&1, "#{prefix}_"))
+    |> Enum.map(&String.replace_prefix(&1, "#{prefix}_", ""))
+  end
+
+  defp filter_only_except_for_assoc(_, _), do: nil
 end

--- a/lib/ex_sieve/node/condition.ex
+++ b/lib/ex_sieve/node/condition.ex
@@ -47,7 +47,7 @@ defmodule ExSieve.Node.Condition do
   @spec extract(String.t() | atom, values, atom, Config.t()) ::
           t | {:error, :predicate_not_found | :value_is_empty | :attribute_not_found}
   def extract(key, values, module, config) do
-    with {:ok, attributes} <- extract_attributes(key, module),
+    with {:ok, attributes} <- extract_attributes(key, module, config),
          {:ok, predicate} <- get_predicate(key, config),
          {:ok, values} <- prepare_values(values) do
       %Condition{
@@ -59,11 +59,11 @@ defmodule ExSieve.Node.Condition do
     end
   end
 
-  defp extract_attributes(key, module) do
+  defp extract_attributes(key, module, config) do
     key
     |> String.split(~r/_(and|or)_/)
     |> Enum.reduce_while({:ok, []}, fn attr_key, {:ok, acc} ->
-      case Attribute.extract(attr_key, module) do
+      case Attribute.extract(attr_key, module, config) do
         {:error, _} = err -> {:halt, err}
         attribute -> {:cont, {:ok, [attribute | acc]}}
       end

--- a/lib/ex_sieve/node/grouping.ex
+++ b/lib/ex_sieve/node/grouping.ex
@@ -41,7 +41,7 @@ defmodule ExSieve.Node.Grouping do
 
   defp extract_conditions(conditions, schema, config) do
     conditions
-    |> Enum.map(fn {key, value} -> Condition.extract(key, value, schema) end)
+    |> Enum.map(fn {key, value} -> Condition.extract(key, value, schema, config) end)
     |> Utils.get_error(config)
   end
 end

--- a/lib/ex_sieve/node/sort.ex
+++ b/lib/ex_sieve/node/sort.ex
@@ -5,22 +5,24 @@ defmodule ExSieve.Node.Sort do
 
   @type t :: %__MODULE__{}
 
+  alias ExSieve.Config
   alias ExSieve.Node.{Attribute, Sort}
 
   @directions ~w(desc asc)
 
-  @spec extract(String.t() | list(String.t()), atom) :: list(t | {:error, :attribute_not_found | :direction_not_found})
-  def extract(value, schema) when is_bitstring(value) do
+  @spec extract(String.t() | list(String.t()), atom, Config.t()) ::
+          list(t | {:error, :attribute_not_found | :direction_not_found})
+  def extract(value, schema, config) when is_bitstring(value) do
     value
-    |> build(schema)
+    |> build(schema, config)
     |> List.wrap()
   end
 
-  def extract(values, schema), do: Enum.map(values, &build(&1, schema))
+  def extract(values, schema, config), do: Enum.map(values, &build(&1, schema, config))
 
-  defp build(value, schema) do
+  defp build(value, schema, config) do
     value
-    |> Attribute.extract(schema)
+    |> Attribute.extract(schema, config)
     |> result(parse_direction(value))
   end
 

--- a/lib/ex_sieve/utils.ex
+++ b/lib/ex_sieve/utils.ex
@@ -12,4 +12,12 @@ defmodule ExSieve.Utils do
   def get_error([{:error, _} | t], config, acc), do: get_error(t, config, acc)
   def get_error([item | t], config, acc), do: get_error(t, config, [item | acc])
   def get_error([], _config, acc), do: acc
+
+  def filter(list, only, except) do
+    cond do
+      is_list(only) -> list -- list -- only
+      is_list(except) -> list -- except
+      true -> list
+    end
+  end
 end

--- a/test/ex_sieve/node/attribute_test.exs
+++ b/test/ex_sieve/node/attribute_test.exs
@@ -1,36 +1,71 @@
 defmodule ExSieve.Node.AttributeTest do
   use ExUnit.Case
 
+  alias ExSieve.Config
   alias ExSieve.{Node.Attribute, Post, Comment}
 
+  setup do
+    {:ok, config: %Config{ignore_errors: false}}
+  end
+
   describe "ExSieve.Node.Attribute.extract/2" do
-    test "return Attribute with parent belongs_to" do
-      assert %Attribute{parent: :post, name: :body} == Attribute.extract("post_body_eq", Comment)
+    test "return Attribute with parent belongs_to", %{config: config} do
+      assert %Attribute{parent: :post, name: :body} == Attribute.extract("post_body_eq", Comment, config)
     end
 
-    test "return Attribute with has_many parent" do
-      assert %Attribute{parent: :comments, name: :id} == Attribute.extract("comments_id_in", Post)
+    test "return Attribute with has_many parent", %{config: config} do
+      assert %Attribute{parent: :comments, name: :id} == Attribute.extract("comments_id_in", Post, config)
     end
 
-    test "return Attribute without parent" do
-      assert %Attribute{name: :id, parent: :query} == Attribute.extract("id_eq", Comment)
+    test "return Attribute without parent", %{config: config} do
+      assert %Attribute{name: :id, parent: :query} == Attribute.extract("id_eq", Comment, config)
     end
 
-    test "return Attributes for schema with similar fields names" do
-      assert %Attribute{name: :published, parent: :query} == Attribute.extract("published_eq", Post)
-      assert %Attribute{name: :published_at, parent: :query} == Attribute.extract("published_at_eq", Post)
+    test "return Attributes for schema with similar fields names", %{config: config} do
+      assert %Attribute{name: :published, parent: :query} == Attribute.extract("published_eq", Post, config)
+      assert %Attribute{name: :published_at, parent: :query} == Attribute.extract("published_at_eq", Post, config)
     end
 
-    test "return Attribute with belongs_to parent" do
-      assert %Attribute{name: :name, parent: :user} == Attribute.extract("user_name_cont_all", Comment)
+    test "return Attribute with belongs_to parent", %{config: config} do
+      assert %Attribute{name: :name, parent: :user} == Attribute.extract("user_name_cont_all", Comment, config)
     end
 
-    test "return {:error, :attribute_not_found}" do
-      assert {:error, :attribute_not_found} == Attribute.extract("tid_eq", Comment)
+    test "return Attribute for attribute in only" do
+      config = %Config{ignore_errors: false, only_attributes: ["id"]}
+      assert %Attribute{} = Attribute.extract("id_eq", Post, config)
     end
 
-    test "return {:error, :attribute_not_found} when parent attribute doesn't exist" do
-      assert {:error, :attribute_not_found} == Attribute.extract("post_tid", Comment)
+    test "return Attribute for attribute not in except" do
+      config = %Config{ignore_errors: false, except_attributes: ["title"]}
+      assert %Attribute{} = Attribute.extract("body_not_cont", Post, config)
+    end
+
+    test "return Attribute for assoc attribute in only" do
+      config = %Config{ignore_errors: false, only_attributes: ["post_id"]}
+      assert %Attribute{} = Attribute.extract("post_id_eq", Comment, config)
+    end
+
+    test "return {:error, :attribute_not_found}", %{config: config} do
+      assert {:error, :attribute_not_found} == Attribute.extract("tid_eq", Comment, config)
+    end
+
+    test "return {:error, :attribute_not_found} when parent attribute doesn't exist", %{config: config} do
+      assert {:error, :attribute_not_found} == Attribute.extract("post_tid", Comment, config)
+    end
+
+    test "return {:error, :attribute_not_found} for excluded attribute" do
+      config = %Config{ignore_errors: false, except_attributes: ["body"]}
+      assert {:error, :attribute_not_found} == Attribute.extract("body_eq", Comment, config)
+    end
+
+    test "return {:error, :attribute_not_found} for excluded assoc attribute" do
+      config = %Config{ignore_errors: false, except_attributes: ["post_title"]}
+      assert {:error, :attribute_not_found} == Attribute.extract("post_title_eq", Comment, config)
+    end
+
+    test "return {:error, :attribute_not_found} for attribute not in only" do
+      config = %Config{ignore_errors: false, only_attributes: ["body"]}
+      assert {:error, :attribute_not_found} == Attribute.extract("title_eq", Post, config)
     end
   end
 end

--- a/test/ex_sieve/node/condition_test.exs
+++ b/test/ex_sieve/node/condition_test.exs
@@ -1,59 +1,84 @@
 defmodule ExSieve.Node.ConditionTest do
   use ExUnit.Case
 
+  alias ExSieve.Config
   alias ExSieve.{Node.Condition, Comment}
 
+  setup do
+    {:ok, config: %Config{ignore_errors: false}}
+  end
+
   describe "ExSieve.Node.Condition.extract/3" do
-    test "return Condition with without combinator" do
-      condition = Condition.extract("post_id_eq", 1, Comment)
+    test "return Condition with without combinator", %{config: config} do
+      condition = Condition.extract("post_id_eq", 1, Comment, config)
       assert condition.values == [1]
       assert condition.combinator == :and
       assert condition.predicate == :eq
       assert length(condition.attributes) == 1
     end
 
-    test "return Condition with combinator or" do
-      condition = Condition.extract("post_id_or_id_cont", 1, Comment)
+    test "return Condition with combinator or", %{config: config} do
+      condition = Condition.extract("post_id_or_id_cont", 1, Comment, config)
       assert condition.values == [1]
       assert condition.combinator == :or
       assert condition.predicate == :cont
       assert length(condition.attributes) == 2
     end
 
-    test "return Condition with combinator and" do
-      condition = Condition.extract("post_id_and_id_in", 1, Comment)
+    test "return Condition with combinator and", %{config: config} do
+      condition = Condition.extract("post_id_and_id_in", 1, Comment, config)
       assert condition.values == [1]
       assert condition.combinator == :and
       assert condition.predicate == :in
       assert length(condition.attributes) == 2
     end
 
-    test "return Condition with combinator cont_all" do
-      condition = Condition.extract("post_id_and_id_cont_all", [1, 2], Comment)
+    test "return Condition with combinator cont_all", %{config: config} do
+      condition = Condition.extract("post_id_and_id_cont_all", [1, 2], Comment, config)
       assert condition.values == [1, 2]
       assert condition.combinator == :and
       assert condition.predicate == :cont_all
       assert length(condition.attributes) == 2
     end
 
-    test "return Condition with combinator gteq" do
-      condition = Condition.extract("post_id_gteq", 2, Comment)
+    test "return Condition with combinator gteq", %{config: config} do
+      condition = Condition.extract("post_id_gteq", 2, Comment, config)
       assert condition.values == [2]
       assert condition.combinator == :and
       assert condition.predicate == :gteq
       assert length(condition.attributes) == 1
     end
 
-    test "return {:error, :predicate_not_found}" do
-      assert {:error, :predicate_not_found} == Condition.extract("post_id_and_id", 1, Comment)
+    test "return Condition for predicate in only" do
+      config = %Config{ignore_errors: false, only_predicates: ["eq"]}
+      assert %Condition{} = Condition.extract("post_id_eq", 1, Comment, config)
     end
 
-    test "return {:error, :attribute_not_found}" do
-      assert {:error, :attribute_not_found} == Condition.extract("tid_eq", 1, Comment)
+    test "return Condition for predicate not in except" do
+      config = %Config{ignore_errors: false, except_predicates: ["cont"]}
+      assert %Condition{} = Condition.extract("body_not_cont", 1, Comment, config)
     end
 
-    test "return {:error, :value_is_empty}" do
-      assert {:error, :value_is_empty} == Condition.extract("id_eq", "", Comment)
+    test "return {:error, :predicate_not_found}", %{config: config} do
+      assert {:error, :predicate_not_found} == Condition.extract("post_id_and_id", 1, Comment, config)
+    end
+
+    test "return {:error, :predicate_not_found} for excluded predicate" do
+      config = %Config{ignore_errors: false, except_predicates: ["eq"]}
+      assert {:error, :predicate_not_found} == Condition.extract("post_id_eq", 1, Comment, config)
+    end
+
+    test "return {:error, :predicate_not_found} for predicate not in only" do
+      config = %Config{ignore_errors: false, only_predicates: ["eq"]}
+      assert {:error, :predicate_not_found} == Condition.extract("post_id_in", 1, Comment, config)
+    end
+
+    test "return {:error, :attribute_not_found}", %{config: config} do
+      assert {:error, :attribute_not_found} == Condition.extract("tid_eq", 1, Comment, config)
+    end
+
+    test "return {:error, :value_is_empty}", %{config: config} do
+      assert {:error, :value_is_empty} == Condition.extract("id_eq", "", Comment, config)
     end
   end
 end

--- a/test/ex_sieve/node/sort_test.exs
+++ b/test/ex_sieve/node/sort_test.exs
@@ -1,26 +1,30 @@
 defmodule ExSieve.Node.SortTest do
   use ExUnit.Case, async: true
 
-  alias ExSieve.Comment
+  alias ExSieve.{Comment, Config}
   alias ExSieve.Node.{Sort, Attribute}
 
+  setup do
+    {:ok, config: %Config{ignore_errors: false}}
+  end
+
   describe "Sort.extract/2" do
-    test "return list(Sort.t) for String.t value" do
+    test "return list(Sort.t) for String.t value", %{config: config} do
       sort = %Sort{direction: :asc, attribute: %Attribute{name: :body, parent: :post}}
-      assert [sort] == Sort.extract("post_body asc", Comment)
+      assert [sort] == Sort.extract("post_body asc", Comment, config)
     end
 
-    test "return list(Sort.t) for list(String.t) value" do
+    test "return list(Sort.t) for list(String.t) value", %{config: config} do
       sort = %Sort{direction: :asc, attribute: %Attribute{name: :body, parent: :post}}
-      assert [sort] == Sort.extract(["post_body asc"], Comment)
+      assert [sort] == Sort.extract(["post_body asc"], Comment, config)
     end
 
-    test "return {:error, :direction_not_found}" do
-      assert [{:error, :direction_not_found}] == Sort.extract("post_body_asc", Comment)
+    test "return {:error, :direction_not_found}", %{config: config} do
+      assert [{:error, :direction_not_found}] == Sort.extract("post_body_asc", Comment, config)
     end
 
-    test "return {:error, :attribute_not_found}" do
-      assert [{:error, :attribute_not_found}] == Sort.extract("tid asc", Comment)
+    test "return {:error, :attribute_not_found}", %{config: config} do
+      assert [{:error, :attribute_not_found}] == Sort.extract("tid asc", Comment, config)
     end
   end
 end


### PR DESCRIPTION
This PR adds some configuration parameters to allow the use of a subset of all the available predicates/attributes. The only/except configuration works in the same way as the corresponding parameters of `Phoenix.Router`.

The documentation for `ExSieve.filter/3` callback contains examples of this.