### PR TITLE
Provide extra configuration

### DIFF
--- a/lib/ex_sieve.ex
+++ b/lib/ex_sieve.ex
@@ -1,15 +1,9 @@
 defmodule ExSieve do
   @moduledoc """
-  ExSieve is a object query translator to Ecto.Query.
-  """
+  `ExSieve` is meant to be `use`d by a module implementing `Ecto.Repo` behaviour.
 
-  alias ExSieve.Config
-
-  @doc """
-  ExSieve is meant to be `use`d by a Ecto.Repo.
-
-  When `use`d, an optional default for `ignore_erros` can be provided.
-  If `ignore_erros` is not provided, a default of `true` will be used.
+  When used, optional configuration parameters can be provided.
+  For details about cofngiuration parameters see `t:ExSieve.Config.t/0`.
 
       defmodule MyApp.Repo do
         use Ecto.Repo, otp_app: :my_app
@@ -21,7 +15,7 @@ defmodule ExSieve do
         use ExSieve, ignore_erros: true
       end
 
-    When `use` is called, a `filter` function is defined in the Repo.
+  When `use` is called, a `filter` function is defined in the Repo.
   """
 
   defmacro __using__(opts) do
@@ -36,8 +30,17 @@ defmodule ExSieve do
     end
   end
 
-  @typep error :: :invalid_query | :attribute_not_found | :predicate_not_found | :direction_not_found | :value_is_empty
-  @type result :: Ecto.Query.t() | {:error, error}
+  @type result :: Ecto.Query.t() | error()
+
+  @type error ::
+          {:error, :invalid_query}
+          | {:error, {:too_deep, key :: String.t()}}
+          | {:error, {:predicate_not_found, key :: String.t()}}
+          | {:error, {:attribute_not_found, key :: String.t()}}
+          | {:error, {:direction_not_found, invalid_direction :: String.t()}}
+          | {:error, {:value_is_empty, key :: String.t()}}
+          | {:error, {:invalid_type, field :: String.t()}}
+          | {:error, {:invalid_value, {field :: String.t(), value :: any()}}}
 
   @doc """
   Filters the given query based on params.

--- a/lib/ex_sieve.ex
+++ b/lib/ex_sieve.ex
@@ -31,7 +31,7 @@ defmodule ExSieve do
       @ex_sieve_defaults unquote(opts)
 
       def filter(queryable, params, options \\ %{}) do
-        ExSieve.Filter.filter(queryable, params, Config.new(@ex_sieve_defaults, options))
+        ExSieve.Filter.filter(queryable, params, @ex_sieve_defaults, options)
       end
     end
   end

--- a/lib/ex_sieve/builder.ex
+++ b/lib/ex_sieve/builder.ex
@@ -5,7 +5,11 @@ defmodule ExSieve.Builder do
   alias ExSieve.Builder.{Join, OrderBy, Where}
   alias ExSieve.Node.{Grouping, Sort}
 
-  @spec call(Ecto.Queryable.t(), Grouping.t(), list(Sort.t()), Config.t()) :: {:ok, Ecto.Query.t()} | {:error, any()}
+  @spec call(Ecto.Queryable.t(), Grouping.t(), list(Sort.t()), Config.t()) ::
+          {:ok, Ecto.Query.t()}
+          | {:error, {:predicate_not_found, predicate :: atom()}}
+          | {:error, {:invalid_type, field :: String.t()}}
+          | {:error, {:invalid_value, {field :: String.t(), value :: any()}}}
   def call(query, grouping, sorts, config) do
     with {:ok, query} <- Join.build(query, grouping, sorts),
          {:ok, query} <- Where.build(query, grouping, config),

--- a/lib/ex_sieve/builder/where.ex
+++ b/lib/ex_sieve/builder/where.ex
@@ -36,16 +36,24 @@ defmodule ExSieve.Builder.Where do
   ]
 
   @basic_predicates Enum.map(@predicates_opts, &elem(&1, 0))
+  @basic_predicates_str Enum.map(@basic_predicates, &Atom.to_string/1)
 
   @all_any_predicates Enum.flat_map(@predicates_opts, fn {predicate, _, _, all_any} ->
                         Enum.map(all_any, &:"#{predicate}_#{&1}")
                       end)
+  @all_any_predicates_str Enum.map(@all_any_predicates, &Atom.to_string/1)
 
   @predicates @basic_predicates ++ @all_any_predicates
-  @predicates_str Enum.map(@predicates, &Atom.to_string/1)
+  @predicates_str @basic_predicates_str ++ @all_any_predicates_str
 
   @spec predicates() :: [String.t()]
   def predicates, do: @predicates_str
+
+  @spec basic_predicates :: [String.t()]
+  def basic_predicates, do: @basic_predicates_str
+
+  @spec composite_predicates :: [String.t()]
+  def composite_predicates, do: @all_any_predicates_str
 
   @spec build(Ecto.Queryable.t(), Grouping.t(), Config.t()) :: {:ok, Ecto.Query.t()} | {:error, any()}
   def build(query, %Grouping{combinator: combinator} = grouping, config) when combinator in ~w(and or)a do

--- a/lib/ex_sieve/config.ex
+++ b/lib/ex_sieve/config.ex
@@ -3,13 +3,17 @@ defmodule ExSieve.Config do
   A `ExSieve.Config` can be created with a `ignore_errors` true or false
   ```
   %ExSieve.Config{
-    ignore_errors: true
+    ignore_errors: true,
+    max_depth: :full
   }
   ```
   """
-  defstruct ignore_errors: true
+  defstruct ignore_errors: true, max_depth: :full
 
-  @type t :: %__MODULE__{}
+  @type t :: %__MODULE__{
+          ignore_errors: boolean(),
+          max_depth: non_neg_integer() | :full
+        }
 
   @doc false
   @spec new(Keyword.t(), call_options :: map, schema :: module()) :: ExSieve.Config.t()

--- a/lib/ex_sieve/config.ex
+++ b/lib/ex_sieve/config.ex
@@ -4,15 +4,20 @@ defmodule ExSieve.Config do
   ```
   %ExSieve.Config{
     ignore_errors: true,
-    max_depth: :full
+    max_depth: :full,
+    except_predicates: nil,
+    only_predicates: nil
   }
   ```
   """
-  defstruct ignore_errors: true, max_depth: :full
+
+  defstruct ignore_errors: true, max_depth: :full, except_predicates: nil, only_predicates: nil
 
   @type t :: %__MODULE__{
           ignore_errors: boolean(),
-          max_depth: non_neg_integer() | :full
+          max_depth: non_neg_integer() | :full,
+          except_predicates: [String.t() | :baisc | :composite] | nil,
+          only_predicates: [String.t() | :baisc | :composite] | nil
         }
 
   @doc false

--- a/lib/ex_sieve/config.ex
+++ b/lib/ex_sieve/config.ex
@@ -1,24 +1,21 @@
 defmodule ExSieve.Config do
-  @moduledoc """
-  A `ExSieve.Config` can be created with a `ignore_errors` true or false
-  ```
-  %ExSieve.Config{
-    ignore_errors: true,
-    max_depth: :full,
-    except_predicates: nil,
-    only_predicates: nil
-  }
-  ```
-  """
-
   defstruct ignore_errors: true, max_depth: :full, except_predicates: nil, only_predicates: nil
 
+  @typedoc """
+  `ExSieve` configuration options:
+    * `ignore_errors`
+    * `max_depth`
+    * `except_predicates`
+    * `only_predicates`
+  """
   @type t :: %__MODULE__{
           ignore_errors: boolean(),
           max_depth: non_neg_integer() | :full,
-          except_predicates: [String.t() | :baisc | :composite] | nil,
-          only_predicates: [String.t() | :baisc | :composite] | nil
+          except_predicates: [String.t() | :basic | :composite] | nil,
+          only_predicates: [String.t() | :basic | :composite] | nil
         }
+
+  @keys [:ignore_errors, :max_depth, :except_predicates, :only_predicates]
 
   @doc false
   @spec new(Keyword.t(), call_options :: map, schema :: module()) :: ExSieve.Config.t()
@@ -31,13 +28,14 @@ defmodule ExSieve.Config do
       defaults
       |> Map.merge(schema_options)
       |> Map.merge(call_options)
+      |> Map.take(@keys)
 
     struct(ExSieve.Config, opts)
   end
 
   defp options_from_schema(schema) do
     cond do
-      function_exported?(schema, :ex_sieve_options, 0) -> apply(schema, :ex_sieve_options, [])
+      function_exported?(schema, :__ex_sieve_options__, 0) -> apply(schema, :__ex_sieve_options__, [])
       true -> %{}
     end
   end

--- a/lib/ex_sieve/config.ex
+++ b/lib/ex_sieve/config.ex
@@ -3,10 +3,24 @@ defmodule ExSieve.Config do
 
   @typedoc """
   `ExSieve` configuration options:
-    * `ignore_errors`
-    * `max_depth`
-    * `except_predicates`
-    * `only_predicates`
+
+    * `:ignore_errors` - when `true` recoverable errors are ignored. Recoverable
+    errors include for instance missing attribute or missing predicate, in that
+    case the query is returned without taking into account the filter causing the
+    error. Defaults to `true`
+
+    * `:max_depth` - the maximum level of nested relations that can be queried.
+    Defaults to `:full` meaning no limit
+
+    * `:only_predicates` - a list of allowed predicates. The list can contain `:basic`
+    and `:composite`, in that case all corresponding predicates are added to the list.
+    When not given or when `nil` no limit is applied. Defaults to `nil`
+
+    * `:except_predicates` - a list of excluded predicates. The list can contain `:basic`
+    and `:composite`, in that case all corresponding predicates are added to the list.
+    When not given or when `nil` no limit is applied. If both `:only_predicates` and
+    `:except_predicates` are given `:only_predicates` takes precedence and
+    `:except_predicates` is ignored. Defaults to `nil`
   """
   @type t :: %__MODULE__{
           ignore_errors: boolean(),
@@ -18,7 +32,7 @@ defmodule ExSieve.Config do
   @keys [:ignore_errors, :max_depth, :except_predicates, :only_predicates]
 
   @doc false
-  @spec new(Keyword.t(), call_options :: map, schema :: module()) :: ExSieve.Config.t()
+  @spec new(Keyword.t(), call_options :: map, schema :: module()) :: __MODULE__.t()
   def new(defaults, call_options, schema) do
     defaults = normalize_options(defaults)
     call_options = normalize_options(call_options)
@@ -30,7 +44,7 @@ defmodule ExSieve.Config do
       |> Map.merge(call_options)
       |> Map.take(@keys)
 
-    struct(ExSieve.Config, opts)
+    struct(__MODULE__, opts)
   end
 
   defp options_from_schema(schema) do

--- a/lib/ex_sieve/filter.ex
+++ b/lib/ex_sieve/filter.ex
@@ -4,27 +4,13 @@ defmodule ExSieve.Filter do
   alias ExSieve.{Builder, Config, Node, Utils}
 
   @spec filter(Ecto.Queryable.t(), %{(binary | atom) => term}, defaults :: Keyword.t(), options :: map) ::
-          ExSieve.result() | {:error, any()}
+          ExSieve.result()
   def filter(queryable, params, defaults \\ [], options \\ %{}) do
-    case Utils.extract_schema(queryable) do
-      {:ok, schema} ->
-        config = Config.new(defaults, options, schema)
-
-        params
-        |> Node.call(schema, config)
-        |> result(queryable, config)
-
-      {:error, _} = err ->
-        err
-    end
-  end
-
-  defp result({:error, reason}, _queryable, _config), do: {:error, reason}
-
-  defp result({:ok, groupings, sorts}, queryable, config) do
-    case Builder.call(queryable, groupings, sorts, config) do
-      {:ok, result} -> result
-      err -> err
+    with {:ok, schema} <- Utils.extract_schema(queryable),
+         config <- Config.new(defaults, options, schema),
+         {:ok, groupings, sorts} <- Node.call(params, schema, config),
+         {:ok, result} <- Builder.call(queryable, groupings, sorts, config) do
+      result
     end
   end
 end

--- a/lib/ex_sieve/filter.ex
+++ b/lib/ex_sieve/filter.ex
@@ -1,17 +1,20 @@
 defmodule ExSieve.Filter do
   @moduledoc false
 
-  alias ExSieve.{Builder, Config, Node}
+  alias ExSieve.{Builder, Config, Node, Utils}
 
-  @spec filter(Ecto.Queryable.t(), %{(binary | atom) => term}, Config.t()) :: ExSieve.result() | {:error, any()}
-  def filter(queryable, params, %Config{} = config) do
-    case extract_schema(queryable) do
+  @spec filter(Ecto.Queryable.t(), %{(binary | atom) => term}, defaults :: Keyword.t(), options :: map) ::
+          ExSieve.result() | {:error, any()}
+  def filter(queryable, params, defaults \\ [], options \\ %{}) do
+    case Utils.extract_schema(queryable) do
       {:ok, schema} ->
+        config = Config.new(defaults, options, schema)
+
         params
         |> Node.call(schema, config)
         |> result(queryable, config)
 
-      err ->
+      {:error, _} = err ->
         err
     end
   end
@@ -22,15 +25,6 @@ defmodule ExSieve.Filter do
     case Builder.call(queryable, groupings, sorts, config) do
       {:ok, result} -> result
       err -> err
-    end
-  end
-
-  defp extract_schema(%Ecto.Query{from: %{source: {_, module}}}), do: extract_schema(module)
-
-  defp extract_schema(schema) when is_atom(schema) do
-    cond do
-      function_exported?(schema, :__schema__, 1) -> {:ok, schema}
-      true -> {:error, :invalid_query}
     end
   end
 end

--- a/lib/ex_sieve/node.ex
+++ b/lib/ex_sieve/node.ex
@@ -9,14 +9,14 @@ defmodule ExSieve.Node do
   @spec call(%{(atom | binary) => term}, atom, Config.t()) :: {:ok, Grouping.t(), list(Sort.t())} | error
   def call(params_with_sort, schema, config) do
     params_with_sort = stringify_keys(params_with_sort)
-    {params, sorts} = extract_sorts(params_with_sort, schema)
+    {params, sorts} = extract_sorts(params_with_sort, schema, config)
     grouping = Grouping.extract(params, schema, config)
     result(grouping, Utils.get_error(sorts, config))
   end
 
-  defp extract_sorts(params, schema) do
+  defp extract_sorts(params, schema, config) do
     {sorts, params} = Map.pop(params, "s", [])
-    {params, Sort.extract(sorts, schema)}
+    {params, Sort.extract(sorts, schema, config)}
   end
 
   defp result({:error, reason}, _sorts), do: {:error, reason}

--- a/lib/ex_sieve/node.ex
+++ b/lib/ex_sieve/node.ex
@@ -4,24 +4,28 @@ defmodule ExSieve.Node do
   alias ExSieve.Node.{Grouping, Sort}
   alias ExSieve.{Config, Utils}
 
-  @typep error :: {:error, :attribute_not_found | :predicate_not_found | :direction_not_found}
+  @type error ::
+          {:error, {:too_deep, key :: String.t()}}
+          | {:error, {:predicate_not_found, key :: String.t()}}
+          | {:error, {:attribute_not_found, key :: String.t()}}
+          | {:error, {:direction_not_found, invalid_direction :: String.t()}}
+          | {:error, {:value_is_empty, key :: String.t()}}
 
   @spec call(%{(atom | binary) => term}, atom, Config.t()) :: {:ok, Grouping.t(), list(Sort.t())} | error
   def call(params_with_sort, schema, config) do
     params_with_sort = stringify_keys(params_with_sort)
     {params, sorts} = extract_sorts(params_with_sort, schema, config)
-    grouping = Grouping.extract(params, schema, config)
-    result(grouping, Utils.get_error(sorts, config))
+
+    with sorts when is_list(sorts) <- Utils.get_error(sorts, config),
+         %Grouping{} = grouping <- Grouping.extract(params, schema, config) do
+      {:ok, grouping, sorts}
+    end
   end
 
   defp extract_sorts(params, schema, config) do
     {sorts, params} = Map.pop(params, "s", [])
     {params, Sort.extract(sorts, schema, config)}
   end
-
-  defp result({:error, reason}, _sorts), do: {:error, reason}
-  defp result(_grouping, {:error, reason}), do: {:error, reason}
-  defp result(grouping, sorts), do: {:ok, grouping, sorts}
 
   defp stringify_keys(nil), do: nil
   defp stringify_keys(%{__struct__: _struct} = value), do: value

--- a/lib/ex_sieve/node/attribute.ex
+++ b/lib/ex_sieve/node/attribute.ex
@@ -3,12 +3,13 @@ defmodule ExSieve.Node.Attribute do
 
   defstruct name: nil, parent: nil, type: nil
 
+  alias ExSieve.Config
   alias ExSieve.Node.Attribute
 
   @type t :: %__MODULE__{}
 
-  @spec extract(key :: String.t(), module | %{related: module}) :: t() | {:error, :attribute_not_found}
-  def extract(key, module) do
+  @spec extract(key :: String.t(), module | %{related: module}, Config.t()) :: t() | {:error, :attribute_not_found}
+  def extract(key, module, _config) do
     extract(key, module, {:name, get_name_and_type(module, key)}, [])
   end
 

--- a/lib/ex_sieve/node/attribute.ex
+++ b/lib/ex_sieve/node/attribute.ex
@@ -3,7 +3,7 @@ defmodule ExSieve.Node.Attribute do
 
   defstruct name: nil, parent: nil, type: nil
 
-  alias ExSieve.Config
+  alias ExSieve.{Config, Utils}
   alias ExSieve.Node.Attribute
 
   @type t :: %__MODULE__{}
@@ -46,6 +46,7 @@ defmodule ExSieve.Node.Attribute do
   defp get_assoc(module, key) do
     :associations
     |> module.__schema__()
+    |> Utils.filter_list(nil, not_filterable_fields(module))
     |> find_field(key)
   end
 
@@ -54,6 +55,7 @@ defmodule ExSieve.Node.Attribute do
   defp get_name_and_type(module, key) do
     :fields
     |> module.__schema__()
+    |> Utils.filter_list(nil, not_filterable_fields(module))
     |> find_field(key)
     |> case do
       nil -> nil
@@ -65,5 +67,14 @@ defmodule ExSieve.Node.Attribute do
     fields
     |> Enum.sort_by(&String.length(to_string(&1)), &>=/2)
     |> Enum.find(&String.starts_with?(key, to_string(&1)))
+  end
+
+  defp not_filterable_fields(schema) do
+    schema
+    |> function_exported?(:__ex_sieve_not_filterable_fields__, 0)
+    |> case do
+      true -> apply(schema, :__ex_sieve_not_filterable_fields__, [])
+      false -> nil
+    end
   end
 end

--- a/lib/ex_sieve/node/attribute.ex
+++ b/lib/ex_sieve/node/attribute.ex
@@ -9,7 +9,10 @@ defmodule ExSieve.Node.Attribute do
   @type t :: %__MODULE__{}
 
   @spec extract(key :: String.t(), module | %{related: module}, Config.t()) ::
-          t() | {:error, :attribute_not_found | :too_deep}
+          t()
+          | {:error, {:attribute_not_found, key :: String.t()}}
+          | {:error, {:too_deep, key :: String.t()}}
+
   def extract(key, module, config) do
     extract(key, module, {:name, get_name_and_type(module, key)}, [], config)
   end
@@ -18,7 +21,7 @@ defmodule ExSieve.Node.Attribute do
     if md == :full or (is_integer(md) and length(parents) < md) do
       extract(key, module, {:assoc, get_assoc(module, key)}, parents, config)
     else
-      {:error, :too_deep}
+      {:error, {:too_deep, Utils.rebuild_key(key, parents)}}
     end
   end
 
@@ -26,7 +29,7 @@ defmodule ExSieve.Node.Attribute do
     %Attribute{parent: Enum.reverse(parents), name: name, type: type}
   end
 
-  defp extract(_, _, {:assoc, nil}, _, _), do: {:error, :attribute_not_found}
+  defp extract(key, _, {:assoc, nil}, parents, _), do: {:error, {:attribute_not_found, Utils.rebuild_key(key, parents)}}
 
   defp extract(key, module, {:assoc, assoc}, parents, config) do
     key = String.replace_prefix(key, "#{assoc}_", "")

--- a/lib/ex_sieve/node/condition.ex
+++ b/lib/ex_sieve/node/condition.ex
@@ -1,6 +1,7 @@
 defmodule ExSieve.Node.Condition do
   @moduledoc false
 
+  alias ExSieve.Config
   alias ExSieve.Builder.Where
   alias ExSieve.Node.{Attribute, Condition}
 
@@ -10,10 +11,10 @@ defmodule ExSieve.Node.Condition do
 
   @typep values :: String.t() | integer | list(String.t() | integer)
 
-  @spec extract(String.t() | atom, values, atom) ::
+  @spec extract(String.t() | atom, values, module(), Config.t()) ::
           t | {:error, :predicate_not_found | :value_is_empty | :attribute_not_found}
-  def extract(key, values, module) do
-    with {:ok, attributes} <- extract_attributes(key, module),
+  def extract(key, values, module, config) do
+    with {:ok, attributes} <- extract_attributes(key, module, config),
          {:ok, predicate} <- get_predicate(key),
          {:ok, values} <- prepare_values(values) do
       %Condition{
@@ -25,11 +26,11 @@ defmodule ExSieve.Node.Condition do
     end
   end
 
-  defp extract_attributes(key, module) do
+  defp extract_attributes(key, module, config) do
     key
     |> String.split(~r/_(and|or)_/)
     |> Enum.reduce_while({:ok, []}, fn attr_key, {:ok, acc} ->
-      case Attribute.extract(attr_key, module) do
+      case Attribute.extract(attr_key, module, config) do
         {:error, _} = err -> {:halt, err}
         attribute -> {:cont, {:ok, [attribute | acc]}}
       end

--- a/lib/ex_sieve/node/condition.ex
+++ b/lib/ex_sieve/node/condition.ex
@@ -1,7 +1,7 @@
 defmodule ExSieve.Node.Condition do
   @moduledoc false
 
-  alias ExSieve.Config
+  alias ExSieve.{Config, Utils}
   alias ExSieve.Builder.Where
   alias ExSieve.Node.{Attribute, Condition}
 
@@ -15,7 +15,7 @@ defmodule ExSieve.Node.Condition do
           t | {:error, :predicate_not_found | :value_is_empty | :attribute_not_found}
   def extract(key, values, module, config) do
     with {:ok, attributes} <- extract_attributes(key, module, config),
-         {:ok, predicate} <- get_predicate(key),
+         {:ok, predicate} <- get_predicate(key, config),
          {:ok, values} <- prepare_values(values) do
       %Condition{
         attributes: attributes,
@@ -37,8 +37,28 @@ defmodule ExSieve.Node.Condition do
     end)
   end
 
-  defp get_predicate(key) do
+  defp get_predicate(key, %Config{only_predicates: [:basic]}),
+    do: do_get_predicate(Where.basic_predicates(), key)
+
+  defp get_predicate(key, %Config{only_predicates: [:composite]}),
+    do: do_get_predicate(Where.composite_predicates(), key)
+
+  defp get_predicate(key, %Config{except_predicates: [:basic]}),
+    do: do_get_predicate(Where.composite_predicates(), key)
+
+  defp get_predicate(key, %Config{except_predicates: [:composite]}),
+    do: do_get_predicate(Where.basic_predicates(), key)
+
+  defp get_predicate(key, config) do
+    {only_predicates, except_predicates} = replace_groups(config.only_predicates, config.except_predicates)
+
     Where.predicates()
+    |> Utils.filter_list(only_predicates, except_predicates)
+    |> do_get_predicate(key)
+  end
+
+  defp do_get_predicate(predicates, key) do
+    predicates
     |> Enum.sort_by(&byte_size/1, &>=/2)
     |> Enum.find(&String.ends_with?(key, &1))
     |> case do
@@ -67,4 +87,19 @@ defmodule ExSieve.Node.Condition do
 
   defp prepare_values(""), do: {:error, :value_is_empty}
   defp prepare_values(value), do: {:ok, List.wrap(value)}
+
+  defp replace_groups(nil, except), do: {nil, do_replace_groups(except)}
+  defp replace_groups(only, _), do: {do_replace_groups(only), nil}
+
+  defp do_replace_groups(nil), do: nil
+
+  defp do_replace_groups(predicates) do
+    predicates
+    |> Enum.flat_map(fn
+      :basic -> Where.basic_predicates()
+      :composite -> Where.composite_predicates()
+      other -> [other]
+    end)
+    |> Enum.uniq()
+  end
 end

--- a/lib/ex_sieve/node/grouping.ex
+++ b/lib/ex_sieve/node/grouping.ex
@@ -10,23 +10,24 @@ defmodule ExSieve.Node.Grouping do
 
   @combinators ~w(or and)
 
-  @spec extract(%{binary => term}, atom, Config.t()) :: t | {:error, :predicate_not_found | :value_is_empty}
+  @spec extract(%{binary => term}, atom, Config.t()) ::
+          t()
+          | {:error, {:attribute_not_found, key :: String.t()}}
+          | {:error, {:predicate_not_found, key :: String.t()}}
+          | {:error, {:value_is_empty, key :: String.t()}}
   def extract(params, schema, config) do
     {combinator, params} = Map.pop(params, "m", "and")
     {grouping, params} = Map.pop(params, "g", [])
     conditions = Map.get(params, "c", params)
 
-    conditions
-    |> do_extract(schema, config, valid_combinator(combinator))
-    |> result(extract_groupings(grouping, schema, config))
+    with %Grouping{} = extracted <- do_extract(conditions, schema, config, valid_combinator(combinator)),
+         groupings when is_list(groupings) <- extract_groupings(grouping, schema, config) do
+      %Grouping{extracted | groupings: groupings}
+    end
   end
 
   defp valid_combinator(combinator) when combinator in @combinators, do: String.to_atom(combinator)
   defp valid_combinator(_combinator), do: :and
-
-  defp result({:error, _} = err, _groupings), do: err
-  defp result(_grouping, {:error, _} = err), do: err
-  defp result(grouping, groupings), do: %Grouping{grouping | groupings: groupings}
 
   defp do_extract(conditions, schema, config, combinator) do
     case extract_conditions(conditions, schema, config) do

--- a/lib/ex_sieve/node/grouping.ex
+++ b/lib/ex_sieve/node/grouping.ex
@@ -41,7 +41,7 @@ defmodule ExSieve.Node.Grouping do
 
   defp extract_conditions(conditions, schema, config) do
     conditions
-    |> Enum.map(fn {key, value} -> Condition.extract(key, value, schema) end)
+    |> Enum.map(fn {key, value} -> Condition.extract(key, value, schema, config) end)
     |> Utils.get_error(config)
   end
 end

--- a/lib/ex_sieve/node/sort.ex
+++ b/lib/ex_sieve/node/sort.ex
@@ -11,7 +11,11 @@ defmodule ExSieve.Node.Sort do
   @directions ~w(desc asc)
 
   @spec extract(String.t() | list(String.t()), module(), Config.t()) ::
-          list(t | {:error, :attribute_not_found | :direction_not_found})
+          list(
+            t()
+            | {:error, {:attribute_not_found, key :: String.t()}}
+            | {:error, {:direction_not_found, invalid_direction :: String.t()}}
+          )
   def extract(value, schema, %Config{} = config) when is_bitstring(value) do
     value
     |> build(schema, config)
@@ -26,11 +30,15 @@ defmodule ExSieve.Node.Sort do
     |> result(parse_direction(value))
   end
 
-  defp result(_attribute, nil), do: {:error, :direction_not_found}
+  defp result(_attribute, {:error, invalid_dir}), do: {:error, {:direction_not_found, invalid_dir}}
   defp result({:error, reason}, _direction), do: {:error, reason}
-  defp result(attribute, direction), do: %Sort{attribute: attribute, direction: String.to_atom(direction)}
+  defp result(attribute, {:ok, direction}), do: %Sort{attribute: attribute, direction: String.to_atom(direction)}
 
   defp parse_direction(value) do
-    value |> String.split(~r/\s+/) |> Enum.find(&Enum.member?(@directions, &1))
+    case String.split(value, ~r/\s+/) do
+      [_, direction] when direction in @directions -> {:ok, direction}
+      [_, invalid_direction] -> {:error, invalid_direction}
+      _ -> {:error, value}
+    end
   end
 end

--- a/lib/ex_sieve/node/sort.ex
+++ b/lib/ex_sieve/node/sort.ex
@@ -5,22 +5,24 @@ defmodule ExSieve.Node.Sort do
 
   @type t :: %__MODULE__{}
 
+  alias ExSieve.Config
   alias ExSieve.Node.{Attribute, Sort}
 
   @directions ~w(desc asc)
 
-  @spec extract(String.t() | list(String.t()), atom) :: list(t | {:error, :attribute_not_found | :direction_not_found})
-  def extract(value, schema) when is_bitstring(value) do
+  @spec extract(String.t() | list(String.t()), module(), Config.t()) ::
+          list(t | {:error, :attribute_not_found | :direction_not_found})
+  def extract(value, schema, %Config{} = config) when is_bitstring(value) do
     value
-    |> build(schema)
+    |> build(schema, config)
     |> List.wrap()
   end
 
-  def extract(values, schema), do: Enum.map(values, &build(&1, schema))
+  def extract(values, schema, config), do: Enum.map(values, &build(&1, schema, config))
 
-  defp build(value, schema) do
+  defp build(value, schema, config) do
     value
-    |> Attribute.extract(schema)
+    |> Attribute.extract(schema, config)
     |> result(parse_direction(value))
   end
 

--- a/lib/ex_sieve/schema.ex
+++ b/lib/ex_sieve/schema.ex
@@ -1,6 +1,6 @@
 defmodule ExSieve.Schema do
   @moduledoc """
-  `ExSieve.Schema` is meant to be `use`d by a module using `Ecto.Schema`.
+  `ExSieve.Schema` is meant to be `use`d by modules using `Ecto.Schema`.
 
   When used, optional configuration parameters specific for the schema
   can be provided. For details about cofngiuration parameters see
@@ -35,7 +35,7 @@ defmodule ExSieve.Schema do
       end
 
   Filters for fields that are in the list are ignored (an error is returned
-  if `ignore_errors` is `false`). By default all fields are filterable.
+  if `:ignore_errors` is `false`). By default all fields are filterable.
   """
 
   defmacro __using__(opts) do

--- a/lib/ex_sieve/schema.ex
+++ b/lib/ex_sieve/schema.ex
@@ -1,0 +1,56 @@
+defmodule ExSieve.Schema do
+  @moduledoc """
+  `ExSieve.Schema` is meant to be `use`d by a module using `Ecto.Schema`.
+
+  When used, optional configuration parameters specific for the schema
+  can be provided. For details about cofngiuration parameters see
+  `t:ExSieve.Config.t/0`.
+
+      defmodule MyApp.User do
+        use ExSieve.Schema
+      end
+
+      defmodule MyApp.USer do
+        use ExSieve.Schema, max_depth: 0
+      end
+
+  When using `ExSieve.Schema`, the list of not filterable schema fields can be
+  specified with the `@ex_sieve_not_filterable_fields` module attribute.
+
+      defmodule MyApp.User do
+        use Ecto.Schema
+        use ExSieve.Schema
+
+        @ex_sieve_not_filterable_fields [:name, :inserted_at, :comments]
+
+        schema "users" do
+          has_many :comments, ExSieve.Comment
+          has_many :posts, ExSieve.Post
+
+          field :name
+          field :cash, Money.Ecto.Type
+
+          timestamps()
+        end
+      end
+
+  Filters for fields that are in the list are ignored (an error is returned
+  if `ignore_errors` is `false`). By default all fields are filterable.
+  """
+
+  defmacro __using__(opts) do
+    quote do
+      def __ex_sieve_options__, do: unquote(opts)
+
+      @before_compile unquote(__MODULE__)
+      Module.register_attribute(__MODULE__, :ex_sieve_not_filterable_fields, accumulate: false)
+      Module.put_attribute(__MODULE__, :ex_sieve_not_filterable_fields, :all)
+    end
+  end
+
+  defmacro __before_compile__(_env) do
+    quote do
+      def __ex_sieve_not_filterable_fields__, do: @ex_sieve_not_filterable_fields
+    end
+  end
+end

--- a/lib/ex_sieve/utils.ex
+++ b/lib/ex_sieve/utils.ex
@@ -16,6 +16,15 @@ defmodule ExSieve.Utils do
     _ -> {:error, :invalid_query}
   end
 
+  @spec filter_list([any()], [any()], [any()]) :: [any()]
+  def filter_list(list, only, except) do
+    cond do
+      is_list(only) -> list -- list -- only
+      is_list(except) -> list -- except
+      true -> list
+    end
+  end
+
   defp do_extract_schema(%Ecto.Query{from: %{source: {_, schema}}}) when not is_nil(schema), do: {:ok, schema}
   defp do_extract_schema(_), do: {:error, :invalid_query}
 end

--- a/lib/ex_sieve/utils.ex
+++ b/lib/ex_sieve/utils.ex
@@ -2,6 +2,7 @@ defmodule ExSieve.Utils do
   @moduledoc false
 
   alias ExSieve.Config
+  alias ExSieve.Node.Attribute
 
   @spec get_error(list(any), Config.t()) :: list(any) | {:error, atom}
   def get_error(items, %Config{ignore_errors: true}), do: Enum.reject(items, &match?({:error, _}, &1))
@@ -16,13 +17,28 @@ defmodule ExSieve.Utils do
     _ -> {:error, :invalid_query}
   end
 
-  @spec filter_list([any()], [any()], [any()]) :: [any()]
+  @spec filter_list([any()], any(), any()) :: [any()]
   def filter_list(list, only, except) do
     cond do
       is_list(only) -> list -- list -- only
       is_list(except) -> list -- except
       true -> list
     end
+  end
+
+  @spec rebuild_key(Attribute.t()) :: String.t()
+  def rebuild_key(%Attribute{name: name, parent: parents}), do: rebuild_key(to_string(name), parents)
+
+  @spec rebuild_key(key :: String.t(), parents :: [atom() | String.t()]) :: String.t()
+  def rebuild_key(key, []), do: key |> String.split() |> Enum.at(0)
+
+  def rebuild_key(key, parents) do
+    parents
+    |> Enum.reverse()
+    |> Enum.map(&to_string/1)
+    |> Enum.join("_")
+    |> Kernel.<>("_#{key}")
+    |> rebuild_key([])
   end
 
   defp do_extract_schema(%Ecto.Query{from: %{source: {_, schema}}}) when not is_nil(schema), do: {:ok, schema}

--- a/lib/ex_sieve/utils.ex
+++ b/lib/ex_sieve/utils.ex
@@ -6,4 +6,16 @@ defmodule ExSieve.Utils do
   @spec get_error(list(any), Config.t()) :: list(any) | {:error, atom}
   def get_error(items, %Config{ignore_errors: true}), do: Enum.reject(items, &match?({:error, _}, &1))
   def get_error(items, %Config{ignore_errors: false}), do: Enum.find(items, items, &match?({:error, _}, &1))
+
+  @spec extract_schema(Ecto.Queryable.t()) :: {:ok, module()} | {:error, :invalid_query}
+  def extract_schema(queryable) do
+    queryable
+    |> Ecto.Queryable.to_query()
+    |> do_extract_schema()
+  rescue
+    _ -> {:error, :invalid_query}
+  end
+
+  defp do_extract_schema(%Ecto.Query{from: %{source: {_, schema}}}) when not is_nil(schema), do: {:ok, schema}
+  defp do_extract_schema(_), do: {:error, :invalid_query}
 end

--- a/priv/repo/migrations/1_create_users.exs
+++ b/priv/repo/migrations/1_create_users.exs
@@ -1,9 +1,10 @@
-defmodule ExSieve.Repo.Migrations.CreateAuthor do
+defmodule ExSieve.Repo.Migrations.CreateUsers do
   use Ecto.Migration
 
   def change do
     create table(:users) do
       add :name, :string
+      add :surname, :string
       add :cash, :integer
 
       timestamps()

--- a/priv/repo/migrations/4_create_addresses.exs
+++ b/priv/repo/migrations/4_create_addresses.exs
@@ -1,0 +1,14 @@
+defmodule ExSieve.Repo.Migrations.CreateAddresses do
+  use Ecto.Migration
+
+  def change do
+    create table(:addresses) do
+      add :street, :string
+      add :city, :string
+
+      add :user_id, references(:users)
+
+      timestamps()
+    end
+  end
+end

--- a/test/ex_sieve/builder/where_test.exs
+++ b/test/ex_sieve/builder/where_test.exs
@@ -173,7 +173,7 @@ defmodule ExSieve.Builder.WhereTest do
       assert inspect(base) == ex_sieve
 
       {_base, ex_sieve} = ex_sieve_post_query(%{"id_not_cont" => 1}, false, false, false)
-      assert {:error, {:invalid_type, _}} = ex_sieve
+      assert {:error, {:invalid_type, "id"}} = ex_sieve
     end
 
     test ":lt" do
@@ -249,7 +249,7 @@ defmodule ExSieve.Builder.WhereTest do
       assert inspect(base) == ex_sieve
 
       {_base, ex_sieve} = ex_sieve_post_query(%{"published_matches" => true}, false, false, false)
-      assert {:error, {:invalid_type, _}} = ex_sieve
+      assert {:error, {:invalid_type, "published"}} = ex_sieve
     end
 
     test ":does_not_match" do
@@ -265,7 +265,7 @@ defmodule ExSieve.Builder.WhereTest do
       assert inspect(base) == ex_sieve
 
       {_base, ex_sieve} = ex_sieve_post_query(%{"published_at_does_not_match" => true}, false, false, false)
-      assert {:error, {:invalid_type, _}} = ex_sieve
+      assert {:error, {:invalid_type, "published_at"}} = ex_sieve
     end
 
     test ":start" do
@@ -281,7 +281,7 @@ defmodule ExSieve.Builder.WhereTest do
       assert inspect(base) == ex_sieve
 
       {_base, ex_sieve} = ex_sieve_post_query(%{"published_start" => true}, false, false, false)
-      assert {:error, {:invalid_type, _}} = ex_sieve
+      assert {:error, {:invalid_type, "published"}} = ex_sieve
     end
 
     test ":not_start" do
@@ -297,7 +297,7 @@ defmodule ExSieve.Builder.WhereTest do
       assert inspect(base) == ex_sieve
 
       {_base, ex_sieve} = ex_sieve_post_query(%{"published_not_start" => true}, false, false, false)
-      assert {:error, {:invalid_type, _}} = ex_sieve
+      assert {:error, {:invalid_type, "published"}} = ex_sieve
     end
 
     test ":end" do
@@ -313,7 +313,7 @@ defmodule ExSieve.Builder.WhereTest do
       assert inspect(base) == ex_sieve
 
       {_base, ex_sieve} = ex_sieve_post_query(%{"published_end" => true}, false, false, false)
-      assert {:error, {:invalid_type, _}} = ex_sieve
+      assert {:error, {:invalid_type, "published"}} = ex_sieve
     end
 
     test ":not_end" do
@@ -329,7 +329,7 @@ defmodule ExSieve.Builder.WhereTest do
       assert inspect(base) == ex_sieve
 
       {_base, ex_sieve} = ex_sieve_post_query(%{"published_not_end" => true}, false, false, false)
-      assert {:error, {:invalid_type, _}} = ex_sieve
+      assert {:error, {:invalid_type, "published"}} = ex_sieve
     end
 
     test ":true" do
@@ -345,10 +345,10 @@ defmodule ExSieve.Builder.WhereTest do
       assert inspect(base) == ex_sieve
 
       {_base, ex_sieve} = ex_sieve_post_query(%{"title_true" => true}, false, false, false)
-      assert {:error, {:invalid_type, _}} = ex_sieve
+      assert {:error, {:invalid_type, "title"}} = ex_sieve
 
       {_base, ex_sieve} = ex_sieve_post_query(%{"published_true" => "foo"}, false, false, false)
-      assert {:error, {:invalid_value, _}} = ex_sieve
+      assert {:error, {:invalid_value, {"published", "foo"}}} = ex_sieve
     end
 
     test ":not_true" do
@@ -364,10 +364,10 @@ defmodule ExSieve.Builder.WhereTest do
       assert inspect(base) == ex_sieve
 
       {_base, ex_sieve} = ex_sieve_post_query(%{"title_not_true" => true}, false, false, false)
-      assert {:error, {:invalid_type, _}} = ex_sieve
+      assert {:error, {:invalid_type, "title"}} = ex_sieve
 
       {_base, ex_sieve} = ex_sieve_post_query(%{"published_not_true" => "foo"}, false, false, false)
-      assert {:error, {:invalid_value, _}} = ex_sieve
+      assert {:error, {:invalid_value, {"published", "foo"}}} = ex_sieve
     end
 
     test ":false" do
@@ -383,10 +383,10 @@ defmodule ExSieve.Builder.WhereTest do
       assert inspect(base) == ex_sieve
 
       {_base, ex_sieve} = ex_sieve_post_query(%{"title_false" => true}, false, false, false)
-      assert {:error, {:invalid_type, _}} = ex_sieve
+      assert {:error, {:invalid_type, "title"}} = ex_sieve
 
       {_base, ex_sieve} = ex_sieve_post_query(%{"published_false" => "foo"}, false, false, false)
-      assert {:error, {:invalid_value, _}} = ex_sieve
+      assert {:error, {:invalid_value, {"published", "foo"}}} = ex_sieve
     end
 
     test ":not_false" do
@@ -402,10 +402,10 @@ defmodule ExSieve.Builder.WhereTest do
       assert inspect(base) == ex_sieve
 
       {_base, ex_sieve} = ex_sieve_post_query(%{"title_not_false" => true}, false, false, false)
-      assert {:error, {:invalid_type, _}} = ex_sieve
+      assert {:error, {:invalid_type, "title"}} = ex_sieve
 
       {_base, ex_sieve} = ex_sieve_post_query(%{"published_not_false" => "foo"}, false, false, false)
-      assert {:error, {:invalid_value, _}} = ex_sieve
+      assert {:error, {:invalid_value, {"published", "foo"}}} = ex_sieve
     end
 
     test ":blank" do
@@ -421,10 +421,10 @@ defmodule ExSieve.Builder.WhereTest do
       assert inspect(base) == ex_sieve
 
       {_base, ex_sieve} = ex_sieve_post_query(%{"published_blank" => true}, false, false, false)
-      assert {:error, {:invalid_type, _}} = ex_sieve
+      assert {:error, {:invalid_type, "published"}} = ex_sieve
 
       {_base, ex_sieve} = ex_sieve_post_query(%{"title_blank" => "foo"}, false, false, false)
-      assert {:error, {:invalid_value, _}} = ex_sieve
+      assert {:error, {:invalid_value, {"title", "foo"}}} = ex_sieve
     end
 
     test ":present" do
@@ -440,10 +440,10 @@ defmodule ExSieve.Builder.WhereTest do
       assert inspect(base) == ex_sieve
 
       {_base, ex_sieve} = ex_sieve_post_query(%{"published_present" => true}, false, false, false)
-      assert {:error, {:invalid_type, _}} = ex_sieve
+      assert {:error, {:invalid_type, "published"}} = ex_sieve
 
       {_base, ex_sieve} = ex_sieve_post_query(%{"title_present" => "foo"}, false, false, false)
-      assert {:error, {:invalid_value, _}} = ex_sieve
+      assert {:error, {:invalid_value, {"title", "foo"}}} = ex_sieve
     end
 
     test ":null" do
@@ -456,7 +456,7 @@ defmodule ExSieve.Builder.WhereTest do
       assert query == ex_sieve
 
       {_base, ex_sieve} = ex_sieve_post_query(%{"title_null" => "foo"}, false, false, false)
-      assert {:error, {:invalid_value, _}} = ex_sieve
+      assert {:error, {:invalid_value, {"title", "foo"}}} = ex_sieve
     end
 
     test ":not_null" do
@@ -469,7 +469,7 @@ defmodule ExSieve.Builder.WhereTest do
       assert query == ex_sieve
 
       {_base, ex_sieve} = ex_sieve_post_query(%{"title_not_null" => "foo"}, false, false, false)
-      assert {:error, {:invalid_value, _}} = ex_sieve
+      assert {:error, {:invalid_value, {"title", "foo"}}} = ex_sieve
     end
   end
 
@@ -488,12 +488,12 @@ defmodule ExSieve.Builder.WhereTest do
 
     test "invalid_type" do
       {_, ex_sieve} = ex_sieve_post_query(%{"id_cont_any" => [1, 2]}, false, false, false)
-      assert {:error, {:invalid_type, _}} = ex_sieve
+      assert {:error, {:invalid_type, "id"}} = ex_sieve
     end
 
     test "invalid predicate" do
       {_, ex_sieve} = ex_sieve_post_query(%{"id_lt_all" => [1, 2]}, false, false, false)
-      assert {:error, :predicate_not_found} = ex_sieve
+      assert {:error, {:predicate_not_found, "id_lt_all"}} = ex_sieve
     end
   end
 end

--- a/test/ex_sieve/config_test.exs
+++ b/test/ex_sieve/config_test.exs
@@ -1,0 +1,22 @@
+defmodule ExSieve.ConfigTest do
+  use ExUnit.Case
+
+  alias ExSieve.{Post, Address}
+  alias ExSieve.Config
+
+  test "invalid options are discarded" do
+    refute Config.new([], %{foo: 1}, Address) |> Map.has_key?(:foo)
+  end
+
+  test "repo options override defaults" do
+    assert %Config{max_depth: 4} = Config.new([max_depth: 4], %{}, Post)
+  end
+
+  test "schema options override defaults" do
+    assert %Config{max_depth: 3} = Config.new([max_depth: 4], %{}, Address)
+  end
+
+  test "call options override all" do
+    assert %Config{max_depth: 1} = Config.new([], %{max_depth: 1}, Address)
+  end
+end

--- a/test/ex_sieve/node/attribute_test.exs
+++ b/test/ex_sieve/node/attribute_test.exs
@@ -44,6 +44,18 @@ defmodule ExSieve.Node.AttributeTest do
       assert {:error, :attribute_not_found} == Attribute.extract("post_tid", Comment, %Config{})
     end
 
+    test "return {:error, :attribute_not_found} for not filterable field" do
+      assert {:error, :attribute_not_found} == Attribute.extract("inserted_at_eq", Comment, %Config{})
+    end
+
+    test "return {:error, :attribute_not_found} for not filterable field in assoc" do
+      assert {:error, :attribute_not_found} == Attribute.extract("comments_inserted_at_eq", User, %Config{})
+    end
+
+    test "return {:error, :attribute_not_found} for not filterable assoc" do
+      assert {:error, :attribute_not_found} == Attribute.extract("addresses_street_eq", User, %Config{})
+    end
+
     test "return {:error, :too_deep} when max_depth is exceeded" do
       assert {:error, :too_deep} == Attribute.extract("posts_comments_body_cont", User, %Config{max_depth: 0})
       assert {:error, :too_deep} == Attribute.extract("posts_comments_body_cont", User, %Config{max_depth: 1})

--- a/test/ex_sieve/node/attribute_test.exs
+++ b/test/ex_sieve/node/attribute_test.exs
@@ -37,28 +37,35 @@ defmodule ExSieve.Node.AttributeTest do
     end
 
     test "return {:error, :attribute_not_found}" do
-      assert {:error, :attribute_not_found} == Attribute.extract("tid_eq", Comment, %Config{})
+      assert {:error, {:attribute_not_found, "tid_eq"}} == Attribute.extract("tid_eq", Comment, %Config{})
     end
 
     test "return {:error, :attribute_not_found} when parent attribute doesn't exist" do
-      assert {:error, :attribute_not_found} == Attribute.extract("post_tid", Comment, %Config{})
+      assert {:error, {:attribute_not_found, "post_tid"}} == Attribute.extract("post_tid", Comment, %Config{})
     end
 
     test "return {:error, :attribute_not_found} for not filterable field" do
-      assert {:error, :attribute_not_found} == Attribute.extract("inserted_at_eq", Comment, %Config{})
+      assert {:error, {:attribute_not_found, "inserted_at_eq"}} ==
+               Attribute.extract("inserted_at_eq", Comment, %Config{})
     end
 
     test "return {:error, :attribute_not_found} for not filterable field in assoc" do
-      assert {:error, :attribute_not_found} == Attribute.extract("comments_inserted_at_eq", User, %Config{})
+      assert {:error, {:attribute_not_found, "comments_inserted_at_eq"}} ==
+               Attribute.extract("comments_inserted_at_eq", User, %Config{})
     end
 
     test "return {:error, :attribute_not_found} for not filterable assoc" do
-      assert {:error, :attribute_not_found} == Attribute.extract("addresses_street_eq", User, %Config{})
+      assert {:error, {:attribute_not_found, "addresses_street_eq"}} ==
+               Attribute.extract("addresses_street_eq", User, %Config{})
     end
 
     test "return {:error, :too_deep} when max_depth is exceeded" do
-      assert {:error, :too_deep} == Attribute.extract("posts_comments_body_cont", User, %Config{max_depth: 0})
-      assert {:error, :too_deep} == Attribute.extract("posts_comments_body_cont", User, %Config{max_depth: 1})
+      assert {:error, {:too_deep, "posts_comments_body_cont"}} ==
+               Attribute.extract("posts_comments_body_cont", User, %Config{max_depth: 0})
+
+      assert {:error, {:too_deep, "posts_comments_body_cont"}} ==
+               Attribute.extract("posts_comments_body_cont", User, %Config{max_depth: 1})
+
       assert %Attribute{} = Attribute.extract("posts_comments_body_cont", User, %Config{max_depth: 2})
       assert %Attribute{} = Attribute.extract("posts_comments_body_cont", User, %Config{max_depth: :full})
     end

--- a/test/ex_sieve/node/attribute_test.exs
+++ b/test/ex_sieve/node/attribute_test.exs
@@ -1,43 +1,47 @@
 defmodule ExSieve.Node.AttributeTest do
   use ExUnit.Case
 
-  alias ExSieve.{Node.Attribute, Post, Comment, User}
+  alias ExSieve.{Node.Attribute, Config, Post, Comment, User}
 
-  describe "ExSieve.Node.Attribute.extract/2" do
+  describe "ExSieve.Node.Attribute.extract/3" do
     test "return Attribute with parent belongs_to" do
-      assert %Attribute{parent: [:post], name: :body, type: :string} == Attribute.extract("post_body_eq", Comment)
+      assert %Attribute{parent: [:post], name: :body, type: :string} ==
+               Attribute.extract("post_body_eq", Comment, %Config{})
     end
 
     test "return Attribute with has_many parent" do
-      assert %Attribute{parent: [:comments], name: :id, type: :id} == Attribute.extract("comments_id_in", Post)
+      assert %Attribute{parent: [:comments], name: :id, type: :id} ==
+               Attribute.extract("comments_id_in", Post, %Config{})
     end
 
     test "return Attribute without parent" do
-      assert %Attribute{name: :id, parent: [], type: :id} == Attribute.extract("id_eq", Comment)
+      assert %Attribute{name: :id, parent: [], type: :id} == Attribute.extract("id_eq", Comment, %Config{})
     end
 
     test "return Attributes for schema with similar fields names" do
-      assert %Attribute{name: :published, parent: [], type: :boolean} == Attribute.extract("published_eq", Post)
+      assert %Attribute{name: :published, parent: [], type: :boolean} ==
+               Attribute.extract("published_eq", Post, %Config{})
 
       assert %Attribute{name: :published_at, parent: [], type: :naive_datetime} ==
-               Attribute.extract("published_at_eq", Post)
+               Attribute.extract("published_at_eq", Post, %Config{})
     end
 
     test "return Attribute with belongs_to parent" do
-      assert %Attribute{name: :name, parent: [:user], type: :string} == Attribute.extract("user_name_cont_all", Comment)
+      assert %Attribute{name: :name, parent: [:user], type: :string} ==
+               Attribute.extract("user_name_cont_all", Comment, %Config{})
     end
 
     test "return Attribute with nested parents" do
       assert %Attribute{name: :body, parent: [:posts, :comments], type: :string} ==
-               Attribute.extract("posts_comments_body_cont", User)
+               Attribute.extract("posts_comments_body_cont", User, %Config{})
     end
 
     test "return {:error, :attribute_not_found}" do
-      assert {:error, :attribute_not_found} == Attribute.extract("tid_eq", Comment)
+      assert {:error, :attribute_not_found} == Attribute.extract("tid_eq", Comment, %Config{})
     end
 
     test "return {:error, :attribute_not_found} when parent attribute doesn't exist" do
-      assert {:error, :attribute_not_found} == Attribute.extract("post_tid", Comment)
+      assert {:error, :attribute_not_found} == Attribute.extract("post_tid", Comment, %Config{})
     end
   end
 end

--- a/test/ex_sieve/node/attribute_test.exs
+++ b/test/ex_sieve/node/attribute_test.exs
@@ -43,5 +43,12 @@ defmodule ExSieve.Node.AttributeTest do
     test "return {:error, :attribute_not_found} when parent attribute doesn't exist" do
       assert {:error, :attribute_not_found} == Attribute.extract("post_tid", Comment, %Config{})
     end
+
+    test "return {:error, :too_deep} when max_depth is exceeded" do
+      assert {:error, :too_deep} == Attribute.extract("posts_comments_body_cont", User, %Config{max_depth: 0})
+      assert {:error, :too_deep} == Attribute.extract("posts_comments_body_cont", User, %Config{max_depth: 1})
+      assert %Attribute{} = Attribute.extract("posts_comments_body_cont", User, %Config{max_depth: 2})
+      assert %Attribute{} = Attribute.extract("posts_comments_body_cont", User, %Config{max_depth: :full})
+    end
   end
 end

--- a/test/ex_sieve/node/condition_test.exs
+++ b/test/ex_sieve/node/condition_test.exs
@@ -45,8 +45,46 @@ defmodule ExSieve.Node.ConditionTest do
       assert length(condition.attributes) == 1
     end
 
+    test "return Condition for predicate in only" do
+      config = %Config{ignore_errors: false, only_predicates: ["eq"]}
+      assert %Condition{} = Condition.extract("post_id_eq", 1, Comment, config)
+
+      config = %Config{ignore_errors: false, only_predicates: [:basic]}
+      assert %Condition{} = Condition.extract("post_id_eq", 1, Comment, config)
+
+      config = %Config{ignore_errors: false, only_predicates: [:composite, "eq"]}
+      assert %Condition{} = Condition.extract("post_id_eq", 1, Comment, config)
+    end
+
+    test "return Condition for predicate not in except" do
+      config = %Config{ignore_errors: false, except_predicates: ["cont"]}
+      assert %Condition{} = Condition.extract("body_not_cont", ["foo"], Comment, config)
+
+      config = %Config{ignore_errors: false, except_predicates: [:basic]}
+      assert %Condition{} = Condition.extract("body_not_cont_all", ["foo", "bar"], Comment, config)
+
+      config = %Config{ignore_errors: false, except_predicates: [:basic, "cont_all"]}
+      assert %Condition{} = Condition.extract("body_not_cont_all", ["foo", "bar"], Comment, config)
+    end
+
     test "return {:error, :predicate_not_found}" do
       assert {:error, :predicate_not_found} == Condition.extract("post_id_and_id", 1, Comment, %Config{})
+    end
+
+    test "return {:error, :predicate_not_found} for excluded predicate" do
+      config = %Config{ignore_errors: false, except_predicates: ["eq"]}
+      assert {:error, :predicate_not_found} == Condition.extract("post_id_eq", 1, Comment, config)
+
+      config = %Config{ignore_errors: false, except_predicates: [:composite]}
+      assert {:error, :predicate_not_found} == Condition.extract("body_not_cont_all", ["foo", "bar"], Comment, config)
+    end
+
+    test "return {:error, :predicate_not_found} for predicate not in only" do
+      config = %Config{ignore_errors: false, only_predicates: ["eq"]}
+      assert {:error, :predicate_not_found} == Condition.extract("post_id_in", 1, Comment, config)
+
+      config = %Config{ignore_errors: false, only_predicates: [:composite]}
+      assert {:error, :predicate_not_found} == Condition.extract("body_cont", "foo", Comment, config)
     end
 
     test "return {:error, :attribute_not_found}" do

--- a/test/ex_sieve/node/condition_test.exs
+++ b/test/ex_sieve/node/condition_test.exs
@@ -68,32 +68,37 @@ defmodule ExSieve.Node.ConditionTest do
     end
 
     test "return {:error, :predicate_not_found}" do
-      assert {:error, :predicate_not_found} == Condition.extract("post_id_and_id", 1, Comment, %Config{})
+      assert {:error, {:predicate_not_found, "post_id_and_id"}} ==
+               Condition.extract("post_id_and_id", 1, Comment, %Config{})
     end
 
     test "return {:error, :predicate_not_found} for excluded predicate" do
       config = %Config{ignore_errors: false, except_predicates: ["eq"]}
-      assert {:error, :predicate_not_found} == Condition.extract("post_id_eq", 1, Comment, config)
+      assert {:error, {:predicate_not_found, "post_id_eq"}} == Condition.extract("post_id_eq", 1, Comment, config)
 
       config = %Config{ignore_errors: false, except_predicates: [:composite]}
-      assert {:error, :predicate_not_found} == Condition.extract("body_not_cont_all", ["foo", "bar"], Comment, config)
+
+      assert {:error, {:predicate_not_found, "body_not_cont_all"}} ==
+               Condition.extract("body_not_cont_all", ["foo", "bar"], Comment, config)
     end
 
     test "return {:error, :predicate_not_found} for predicate not in only" do
       config = %Config{ignore_errors: false, only_predicates: ["eq"]}
-      assert {:error, :predicate_not_found} == Condition.extract("post_id_in", 1, Comment, config)
+      assert {:error, {:predicate_not_found, "post_id_in"}} == Condition.extract("post_id_in", 1, Comment, config)
 
       config = %Config{ignore_errors: false, only_predicates: [:composite]}
-      assert {:error, :predicate_not_found} == Condition.extract("body_cont", "foo", Comment, config)
+      assert {:error, {:predicate_not_found, "body_cont"}} == Condition.extract("body_cont", "foo", Comment, config)
     end
 
     test "return {:error, :attribute_not_found}" do
-      assert {:error, :attribute_not_found} == Condition.extract("tid_eq", 1, Comment, %Config{})
-      assert {:error, :attribute_not_found} == Condition.extract("posts_comments_foo_eq", 1, User, %Config{})
+      assert {:error, {:attribute_not_found, "tid_eq"}} == Condition.extract("tid_eq", 1, Comment, %Config{})
+
+      assert {:error, {:attribute_not_found, "posts_comments_foo_eq"}} ==
+               Condition.extract("posts_comments_foo_eq", 1, User, %Config{})
     end
 
     test "return {:error, :value_is_empty}" do
-      assert {:error, :value_is_empty} == Condition.extract("id_eq", "", Comment, %Config{})
+      assert {:error, {:value_is_empty, "id_eq"}} == Condition.extract("id_eq", "", Comment, %Config{})
     end
   end
 end

--- a/test/ex_sieve/node/condition_test.exs
+++ b/test/ex_sieve/node/condition_test.exs
@@ -1,11 +1,12 @@
 defmodule ExSieve.Node.ConditionTest do
   use ExUnit.Case
 
+  alias ExSieve.Config
   alias ExSieve.{Node.Condition, Comment, User}
 
-  describe "ExSieve.Node.Condition.extract/3" do
+  describe "ExSieve.Node.Condition.extract/4" do
     test "return Condition with without combinator" do
-      condition = Condition.extract("post_id_eq", 1, Comment)
+      condition = Condition.extract("post_id_eq", 1, Comment, %Config{})
       assert condition.values == [1]
       assert condition.combinator == :and
       assert condition.predicate == :eq
@@ -13,7 +14,7 @@ defmodule ExSieve.Node.ConditionTest do
     end
 
     test "return Condition with combinator or" do
-      condition = Condition.extract("post_id_or_id_cont", 1, Comment)
+      condition = Condition.extract("post_id_or_id_cont", 1, Comment, %Config{})
       assert condition.values == [1]
       assert condition.combinator == :or
       assert condition.predicate == :cont
@@ -21,7 +22,7 @@ defmodule ExSieve.Node.ConditionTest do
     end
 
     test "return Condition with combinator and" do
-      condition = Condition.extract("post_id_and_id_in", 1, Comment)
+      condition = Condition.extract("post_id_and_id_in", 1, Comment, %Config{})
       assert condition.values == [1]
       assert condition.combinator == :and
       assert condition.predicate == :in
@@ -29,7 +30,7 @@ defmodule ExSieve.Node.ConditionTest do
     end
 
     test "return Condition with combinator cont_all" do
-      condition = Condition.extract("post_id_and_id_cont_all", [1, 2], Comment)
+      condition = Condition.extract("post_id_and_id_cont_all", [1, 2], Comment, %Config{})
       assert condition.values == [1, 2]
       assert condition.combinator == :and
       assert condition.predicate == :cont_all
@@ -37,7 +38,7 @@ defmodule ExSieve.Node.ConditionTest do
     end
 
     test "return Condition with combinator gteq" do
-      condition = Condition.extract("post_id_gteq", 2, Comment)
+      condition = Condition.extract("post_id_gteq", 2, Comment, %Config{})
       assert condition.values == [2]
       assert condition.combinator == :and
       assert condition.predicate == :gteq
@@ -45,16 +46,16 @@ defmodule ExSieve.Node.ConditionTest do
     end
 
     test "return {:error, :predicate_not_found}" do
-      assert {:error, :predicate_not_found} == Condition.extract("post_id_and_id", 1, Comment)
+      assert {:error, :predicate_not_found} == Condition.extract("post_id_and_id", 1, Comment, %Config{})
     end
 
     test "return {:error, :attribute_not_found}" do
-      assert {:error, :attribute_not_found} == Condition.extract("tid_eq", 1, Comment)
-      assert {:error, :attribute_not_found} == Condition.extract("posts_comments_foo_eq", 1, User)
+      assert {:error, :attribute_not_found} == Condition.extract("tid_eq", 1, Comment, %Config{})
+      assert {:error, :attribute_not_found} == Condition.extract("posts_comments_foo_eq", 1, User, %Config{})
     end
 
     test "return {:error, :value_is_empty}" do
-      assert {:error, :value_is_empty} == Condition.extract("id_eq", "", Comment)
+      assert {:error, :value_is_empty} == Condition.extract("id_eq", "", Comment, %Config{})
     end
   end
 end

--- a/test/ex_sieve/node/grouping_test.exs
+++ b/test/ex_sieve/node/grouping_test.exs
@@ -86,11 +86,12 @@ defmodule ExSieve.Node.GroupingTest do
     end
 
     test "return {:error, :predicate_not_found}", %{config: config} do
-      assert {:error, :predicate_not_found} == Grouping.extract(%{"post_id_and_id" => 1}, Comment, config)
+      assert {:error, {:predicate_not_found, "post_id_and_id"}} ==
+               Grouping.extract(%{"post_id_and_id" => 1}, Comment, config)
     end
 
     test "return {:error, :attribute_not_found}", %{config: config} do
-      assert {:error, :attribute_not_found} == Grouping.extract(%{"tid_eq" => 1}, Comment, config)
+      assert {:error, {:attribute_not_found, "tid_eq"}} == Grouping.extract(%{"tid_eq" => 1}, Comment, config)
     end
 
     test "return nil when attribute not found and ignore_errors is true" do

--- a/test/ex_sieve/node/sort_test.exs
+++ b/test/ex_sieve/node/sort_test.exs
@@ -21,11 +21,11 @@ defmodule ExSieve.Node.SortTest do
     end
 
     test "return {:error, :direction_not_found}" do
-      assert [{:error, :direction_not_found}] == Sort.extract("post_body_asc", Comment, %Config{})
+      assert [{:error, {:direction_not_found, "foo"}}] == Sort.extract("post_body foo", Comment, %Config{})
     end
 
     test "return {:error, :attribute_not_found}" do
-      assert [{:error, :attribute_not_found}] == Sort.extract("tid asc", Comment, %Config{})
+      assert [{:error, {:attribute_not_found, "tid"}}] == Sort.extract("tid asc", Comment, %Config{})
     end
   end
 end

--- a/test/ex_sieve/node/sort_test.exs
+++ b/test/ex_sieve/node/sort_test.exs
@@ -1,31 +1,31 @@
 defmodule ExSieve.Node.SortTest do
   use ExUnit.Case, async: true
 
-  alias ExSieve.{Comment, User}
+  alias ExSieve.{Comment, Config, User}
   alias ExSieve.Node.{Sort, Attribute}
 
-  describe "Sort.extract/2" do
+  describe "Sort.extract/3" do
     test "return list(Sort.t) for String.t value" do
       sort = %Sort{direction: :asc, attribute: %Attribute{name: :body, parent: [:post], type: :string}}
-      assert [sort] == Sort.extract("post_body asc", Comment)
+      assert [sort] == Sort.extract("post_body asc", Comment, %Config{})
     end
 
     test "return list(Sort.t) for list(String.t) value" do
       sort = %Sort{direction: :asc, attribute: %Attribute{name: :body, parent: [:post], type: :string}}
-      assert [sort] == Sort.extract(["post_body asc"], Comment)
+      assert [sort] == Sort.extract(["post_body asc"], Comment, %Config{})
     end
 
     test "correctly handle nested relations" do
       sort = %Sort{direction: :asc, attribute: %Attribute{name: :body, parent: [:posts, :comments], type: :string}}
-      assert [sort] == Sort.extract(["posts_comments_body asc"], User)
+      assert [sort] == Sort.extract(["posts_comments_body asc"], User, %Config{})
     end
 
     test "return {:error, :direction_not_found}" do
-      assert [{:error, :direction_not_found}] == Sort.extract("post_body_asc", Comment)
+      assert [{:error, :direction_not_found}] == Sort.extract("post_body_asc", Comment, %Config{})
     end
 
     test "return {:error, :attribute_not_found}" do
-      assert [{:error, :attribute_not_found}] == Sort.extract("tid asc", Comment)
+      assert [{:error, :attribute_not_found}] == Sort.extract("tid asc", Comment, %Config{})
     end
   end
 end

--- a/test/ex_sieve_test.exs
+++ b/test/ex_sieve_test.exs
@@ -3,14 +3,12 @@ defmodule ExSieveTest do
 
   import Ecto.Query
 
-  alias ExSieve.{Repo, Comment, Config, User}
-
-  setup do
-    {:ok, config: %Config{ignore_errors: false}}
-  end
+  alias ExSieve.{Repo, Comment, User}
 
   describe "ExSieve.Filter.filter/3" do
-    test "return ordered by id and body", %{config: config} do
+    test "return ordered by id and body" do
+      config = [ignore_errors: false]
+
       [%{body: body} | _] = insert_pair(:post)
 
       ids = Comment |> ExSieve.Filter.filter(%{"post_body_in" => [body], "s" => "post_id desc"}, config) |> ids
@@ -26,7 +24,7 @@ defmodule ExSieveTest do
     end
 
     test "broken query fields doesn't affect to query object" do
-      config = %Config{ignore_errors: true}
+      config = [ignore_errors: true]
 
       [%{body: body} | _] = insert_pair(:post)
 
@@ -36,7 +34,7 @@ defmodule ExSieveTest do
     end
 
     test "broken sort fields doesn't affect to query object" do
-      config = %Config{ignore_errors: true}
+      config = [ignore_errors: true]
 
       [%{body: body} | _] = insert_pair(:post)
 
@@ -51,14 +49,15 @@ defmodule ExSieveTest do
       assert ids == ecto_ids
     end
 
-    test "return users with custom type field", %{config: config} do
+    test "return users with custom type field" do
+      config = [ignore_errors: false]
       insert_pair(:user)
       ids = User |> ExSieve.Filter.filter(%{"cash_lteq" => %Money{amount: 1000}}, config) |> ids()
       assert ids == ids(User)
     end
 
-    test "return error with invalid queries", %{config: config} do
-      assert {:error, :invalid_query} = ExSieve.Filter.filter(InvalidUser, %{}, config)
+    test "return error with invalid queries" do
+      assert {:error, :invalid_query} = ExSieve.Filter.filter(InvalidUser, %{})
     end
   end
 

--- a/test/support/address.ex
+++ b/test/support/address.ex
@@ -1,0 +1,13 @@
+defmodule ExSieve.Address do
+  use Ecto.Schema
+  use ExSieve.Schema, max_depth: 3
+
+  schema "addresses" do
+    belongs_to :user, ExSieve.User
+
+    field :street
+    field :city
+
+    timestamps()
+  end
+end

--- a/test/support/comment.ex
+++ b/test/support/comment.ex
@@ -1,5 +1,8 @@
 defmodule ExSieve.Comment do
   use Ecto.Schema
+  use ExSieve.Schema
+
+  @ex_sieve_not_filterable_fields [:inserted_at]
 
   schema "comments" do
     belongs_to :post, ExSieve.Post

--- a/test/support/user.ex
+++ b/test/support/user.ex
@@ -1,11 +1,16 @@
 defmodule ExSieve.User do
   use Ecto.Schema
+  use ExSieve.Schema
+
+  @ex_sieve_not_filterable_fields [:addresses, :surname]
 
   schema "users" do
     has_many :comments, ExSieve.Comment
     has_many :posts, ExSieve.Post
+    has_many :addresses, ExSieve.Address
 
     field :name
+    field :surname
     field :cash, Money.Ecto.Type
 
     timestamps()


### PR DESCRIPTION
These configuration options are now available:

- `:ignore_errors` - when `true` recoverable errors are ignored. Recoverable errors include for instance missing attribute or missing predicate, in that case the query is returned without taking into account the filter causing the error. Defaults to `true`

- `:max_depth` - the maximum level of nested relations that can be queried. Defaults to `:full` meaning no limit

- `:only_predicates` - a list of allowed predicates. The list can contain `:basic` and `:composite`, in that case all corresponding predicates are added to the list. When not given or when `nil` no limit is applied. Defaults to `nil`

- `:except_predicates` - a list of excluded predicates. The list can contain `:basic` and `:composite`, in that case all correpsonding predicates are added to the list. When not given or when `nil` no limit is applied. If both `:only_predicates` and `:except_predicates` are given `:only_predicates` takes precedence and `:except_predicates` is ignored. Defaults to `nil`

In addition a new `ExSieve.Schema` module allows to override these options on a per-schema basis. One can also set some schema fields as non filterable with the `@ex_sieve_not_filterable_fields` module attribute.